### PR TITLE
Add startElection method to serverRole interface

### DIFF
--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -41,3 +41,8 @@ func (f *followerRole) requestVote(serverTerm int64,
 	s.lastModified = time.Now()
 	return currentTerm, true
 }
+
+func (f *followerRole) startElection(currentTerm int64,
+	localServerID int64) bool {
+	return false
+}

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -152,3 +152,13 @@ func TestRequestVote(t *testing.T) {
 		t.Errorf("requestVote failed although it was expected to succeed")
 	}
 }
+
+func TestStartElection(t *testing.T) {
+	// Instantiate follower
+	f := new(followerRole)
+	elected := f.startElection(-1, -1)
+
+	if elected {
+		t.Errorf("followers cannot start an election")
+	}
+}

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -40,3 +40,8 @@ func (f *leaderRole) requestVote(serverTerm int64, serverID int64,
 	// Candidate term is not greater than server term, deny vote
 	return currentTerm, false
 }
+
+func (f *leaderRole) startElection(currentTerm int64,
+	localServerID int64) bool {
+	return false
+}

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -12,4 +12,9 @@ type serverRole interface {
 	// requestVote implements the logic used to determine whether a server
 	// should grant its vote to an external server for the current term
 	requestVote(int64, int64, *serverState) (int64, bool)
+
+	// startElection starts an election. Only candidates can start an election
+	// and be elected: calling this method on followers and leaders should
+	// automatically return false
+	startElection(int64, int64) bool
 }


### PR DESCRIPTION
This PR adds `startElection` method to the `serverRole` interface and implements it for `followerRole` and `leaderRole`. `startElection` returns `true` if the server was elected leader for the current term, and `false` otherwise. Only a `candidate` server can start an election and be elected: as such, this method should return `false` when invoked on a `candidate` or a `leader`.