### PR TITLE
Add state transitions to serverRole

### DIFF
--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -21,6 +21,17 @@ func (f *followerRole) appendEntry(serverTerm int64,
 	return currentTerm, true
 }
 
+func (f *followerRole) makeCandidate(s *serverState) {
+	// Get current term
+	currentTerm := s.currentTerm()
+
+	// Change role to candidate and update term
+	s.role = candidate
+	s.updateTerm(currentTerm + 1)
+}
+
+func (f *followerRole) makeFollower(serverTerm int64, s *serverState) {}
+
 func (f *followerRole) requestVote(serverTerm int64,
 	serverID int64, s *serverState) (int64, bool) {
 	// Get current term and ID of server that has received this server's vote

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -78,6 +78,36 @@ func TestAppendEntry(t *testing.T) {
 	}
 }
 
+func TestMakeCandidate(t *testing.T) {
+	// Initialize mocked server state dao
+	dao := new(mockedServerStateDao)
+	dao.currentTerm = startingTerm
+	dao.votedFor = startingVotedFor
+
+	// Initialize server state
+	s := new(serverState)
+	s.dao = dao
+
+	// Instantiate follower
+	f := new(followerRole)
+
+	// Change server role to candidate
+	f.makeCandidate(s)
+	term, votedFor := s.votedFor()
+	if term != startingTerm+1 {
+		t.Errorf("wrong term following makeCandidate: expected %d, actual %d",
+			startingTerm+1, term)
+	}
+
+	if votedFor != -1 {
+		t.Errorf("vote should have not been casted following makeCandidate")
+	}
+
+	if s.role != candidate {
+		t.Errorf("role should be candidate following makeCandidate")
+	}
+}
+
 func TestRequestVote(t *testing.T) {
 	// Initialize mocked server state dao
 	dao := new(mockedServerStateDao)

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -8,20 +8,33 @@ func (f *leaderRole) appendEntry(serverTerm int64,
 	serverID int64, s *serverState) (int64, bool) {
 	// Get current term
 	currentTerm := s.currentTerm()
+
+	// No two leaders can be elected during the same term
 	if currentTerm == serverTerm {
 		panic("cannot have more than one leader per term")
 	}
 
-	// appendEntry call came from a previous leader
-	if currentTerm > serverTerm {
-		return currentTerm, false
+	// If calling server term is greater than local server term, role should
+	// have been changed to follower: failure to do so points to a bug
+	if currentTerm < serverTerm {
+		panic("leader has not transitioned to follower before" +
+			"calling appendEntry")
 	}
+	return currentTerm, false
+}
 
-	// appendEntry call came from new leader
-	s.role = follower
-	s.updateTerm(serverTerm)
-	s.lastModified = time.Now()
-	return serverTerm, true
+func (f *leaderRole) makeCandidate(s *serverState) {}
+
+func (f *leaderRole) makeFollower(serverTerm int64, s *serverState) {
+	// Get current term
+	currentTerm := s.currentTerm()
+
+	// If server term greater than current term, change role to follower and
+	// update term
+	if currentTerm < serverTerm {
+		s.role = follower
+		s.updateTerm(serverTerm)
+	}
 }
 
 func (f *leaderRole) requestVote(serverTerm int64, serverID int64,

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -9,6 +9,12 @@ type serverRole interface {
 	// should append a log entry sent by the current leader to its log
 	appendEntry(int64, int64, *serverState) (int64, bool)
 
+	// makeFollower implements the role transition logic to follower
+	makeFollower(int64, *serverState)
+
+	// makeCandidate implements the role transition logic to candidate
+	makeCandidate(*serverState)
+
 	// requestVote implements the logic used to determine whether a server
 	// should grant its vote to an external server for the current term
 	requestVote(int64, int64, *serverState) (int64, bool)

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"sync"
 	"time"
 
 	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
@@ -33,7 +32,6 @@ func getServerState() *serverState {
 
 // serverState represents the state of a Raft server
 type serverState struct {
-	sync.Mutex
 	dao          server_state_dao.ServerStateDao
 	lastModified time.Time
 	role         int


### PR DESCRIPTION
This PR adds methods to implement state transitions to the `serverRole` interface: it also provides an implementation of these state transitions for the `follower` and `leader` roles