### PR TITLE
Add return value to makeFollower and makeCandidate 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .devcontainer
+Dockerfile

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -21,16 +21,19 @@ func (f *followerRole) appendEntry(serverTerm int64,
 	return currentTerm, true
 }
 
-func (f *followerRole) makeCandidate(s *serverState) {
+func (f *followerRole) makeCandidate(s *serverState) bool {
 	// Get current term
 	currentTerm := s.currentTerm()
 
-	// Change role to candidate and update term
+	// Change role to candidate, update term and voted for
 	s.role = candidate
-	s.updateTerm(currentTerm + 1)
+	s.updateTermVotedFor(currentTerm+1, s.serverID)
+	return true
 }
 
-func (f *followerRole) makeFollower(serverTerm int64, s *serverState) {}
+func (f *followerRole) makeFollower(serverTerm int64, s *serverState) bool {
+	return true
+}
 
 func (f *followerRole) requestVote(serverTerm int64,
 	serverID int64, s *serverState) (int64, bool) {

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -87,6 +87,7 @@ func TestMakeCandidate(t *testing.T) {
 	// Initialize server state
 	s := new(serverState)
 	s.dao = dao
+	s.serverID = 2
 
 	// Instantiate follower
 	f := new(followerRole)
@@ -99,8 +100,8 @@ func TestMakeCandidate(t *testing.T) {
 			startingTerm+1, term)
 	}
 
-	if votedFor != -1 {
-		t.Errorf("vote should have not been casted following makeCandidate")
+	if votedFor != 2 {
+		t.Errorf("vote should have been casted for local server")
 	}
 
 	if s.role != candidate {

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -23,18 +23,23 @@ func (f *leaderRole) appendEntry(serverTerm int64,
 	return currentTerm, false
 }
 
-func (f *leaderRole) makeCandidate(s *serverState) {}
+func (f *leaderRole) makeCandidate(s *serverState) bool {
+	return false
+}
 
-func (f *leaderRole) makeFollower(serverTerm int64, s *serverState) {
+func (f *leaderRole) makeFollower(serverTerm int64, s *serverState) bool {
 	// Get current term
 	currentTerm := s.currentTerm()
 
-	// If server term greater than current term, change role to follower and
-	// update term
-	if currentTerm < serverTerm {
-		s.role = follower
-		s.updateTerm(serverTerm)
+	// Leader remains leader ff server term not greater than current term
+	if currentTerm >= serverTerm {
+		return false
 	}
+
+	// Change role to follower and update term
+	s.role = follower
+	s.updateTerm(serverTerm)
+	return true
 }
 
 func (f *leaderRole) requestVote(serverTerm int64, serverID int64,

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -10,10 +10,10 @@ type serverRole interface {
 	appendEntry(int64, int64, *serverState) (int64, bool)
 
 	// makeFollower implements the role transition logic to follower
-	makeFollower(int64, *serverState)
+	makeFollower(int64, *serverState) bool
 
 	// makeCandidate implements the role transition logic to candidate
-	makeCandidate(*serverState)
+	makeCandidate(*serverState) bool
 
 	// requestVote implements the logic used to determine whether a server
 	// should grant its vote to an external server for the current term

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -35,6 +35,7 @@ type serverState struct {
 	dao          server_state_dao.ServerStateDao
 	lastModified time.Time
 	role         int
+	serverID     int64
 }
 
 // currentTerm returns the current term ID


### PR DESCRIPTION
This PR adds a boolean return value to `makeFollower` and `makeCandidate`. Adding a return value will allow the handlers for `appendEntry` and `startElection` to terminate early should the transition to `follower` and `candidate` fail