### PR TITLE
Add RaftService RPC handler

### DIFF
--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"fmt"
-	"time"
 )
 
 const (
@@ -56,19 +55,7 @@ func (l *leaderRole) makeFollower(serverTerm int64, s *serverState) bool {
 
 func (l *leaderRole) requestVote(serverTerm int64, serverID int64,
 	s *serverState) (int64, bool) {
-	// Get current term
-	currentTerm := s.currentTerm()
-
-	// Candidate term is greater than server term, grant vote
-	if currentTerm < serverTerm {
-		s.role = follower
-		s.updateTerm(serverTerm)
-		s.lastModified = time.Now()
-		return serverTerm, true
-	}
-
-	// Candidate term is not greater than server term, deny vote
-	return currentTerm, false
+	panic(fmt.Sprintf(leaderErrFmt, "requestVote"))
 }
 
 func (l *leaderRole) startElection(servers []string,

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -1,0 +1,54 @@
+package domain
+
+import "sync"
+
+type RaftService struct {
+	sync.Mutex
+	state *serverState
+	roles map[int]serverRole
+}
+
+// AppendEntry implements the AppendEntry RPC call. Firstly, RaftService will
+// try changing the server state to follower, since only a follower can append
+// a log entry to its log. If the transition to follower is successful, the
+// service will then forward the request to the underlying server state object,
+// and return the result of the forwarding call to the invoking RPC handler
+func (s *RaftService) AppendEntry(remoteServerTerm int64,
+	remoteServerID int64) (int64, bool) {
+	// Lock access to server state
+	s.Lock()
+	defer s.Unlock()
+
+	// Only a follower can respond to an AppendEntry request
+	if ok := s.roles[state.role].makeFollower(state.currentTerm(),
+		s.state); !ok {
+		return s.state.currentTerm(), false
+	}
+
+	// Append entry to log if possible
+	return s.roles[state.role].appendEntry(remoteServerTerm,
+		remoteServerID, s.state)
+}
+
+// RequestVote implements the RequestVote RPC call. Firstly, RaftService will
+// try changing the server state to follower, since only a follower can cast
+// a vote for a remote server (leaders and candidates will always cast their
+// vote for themselves). If the transition to follower is successful, the
+// service will then ask for a vote on the remote server, and return the
+// result of that call to the invoking RPC handler
+func (s *RaftService) RequestVote(remoteServerTerm int64,
+	remoteServerID int64) (int64, bool) {
+	// Lock access to server state
+	s.Lock()
+	defer s.Unlock()
+
+	// Only a follower can grant its vote to a remote server
+	if ok := s.roles[state.role].makeFollower(state.currentTerm(),
+		s.state); !ok {
+		return s.state.currentTerm(), false
+	}
+
+	// Grant vote if possible
+	return s.roles[state.role].requestVote(remoteServerTerm,
+		remoteServerID, s.state)
+}

--- a/src/handler/grpc_handler.go
+++ b/src/handler/grpc_handler.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giulioborghesi/raft-implementation/src/domain"
+	"github.com/giulioborghesi/raft-implementation/src/service"
+)
+
+type RaftRPCHandler struct {
+	service.UnimplementedRaftServer
+	raftService domain.RaftService
+}
+
+func (h *RaftRPCHandler) AppendEntry(ctx context.Context,
+	request *service.AppendEntryRequest) (*service.AppendEntryReply, error) {
+	return nil, nil
+}
+
+func (h *RaftRPCHandler) RequestVote(ctx context.Context,
+	request *service.RequestVoteRequest) (*service.RequestVoteReply, error) {
+	// Forward call arguments to RaftService
+	localServerTerm, success := h.raftService.RequestVote(request.ServerTerm,
+		request.ServerID)
+
+	// Prepare reply and return
+	return &service.RequestVoteReply{Success: success,
+		ServerTerm: localServerTerm}, nil
+}


### PR DESCRIPTION
This PR adds a RPC handler for the Raft RPC calls as well as a RaftService that is used to implement the RPC calls.