### PR TITLE
Clean up code comments and rename timeout handler

### DIFF
--- a/src/domain/abstract_raft_service.go
+++ b/src/domain/abstract_raft_service.go
@@ -3,15 +3,15 @@ package domain
 import "time"
 
 type AbstractRaftService interface {
-	// AppendEntry implements the AppendEntry RPC call
+	// AppendEntry is the abstract method called by the AppendEntry RPC call
 	AppendEntry(remoteServerTerm int64, remoteServerID int64) (int64, bool)
 
-	// lastModified returns the time of last modification
+	// lastModified returns the time of last server modification
 	lastModified() time.Time
 
-	// RequestVote implements the RequestVote RPC call
+	// RequestVote is the abstract method called by the RequestVote RPC call
 	RequestVote(remoteServerTerm int64, remoteServerID int64) (int64, bool)
 
-	// StartElection attempts to start an election
+	// StartElection initiates an election based on the latest timeout
 	StartElection(time.Duration)
 }

--- a/src/domain/timeout_generator_test.go
+++ b/src/domain/timeout_generator_test.go
@@ -80,9 +80,9 @@ func TestSleepTime(t *testing.T) {
 
 }
 
-func TestElectionTimeoutHandler(t *testing.T) {
-	// Create timeout handler
-	handler := timeoutHandler{active: true, tLastHandler: lastModified,
+func TestTimeoutGenerator(t *testing.T) {
+	// Create timeout generator
+	handler := timeoutGenerator{active: true, tLastHandler: lastModified,
 		tOutHandler: timeOutHandler, toMin: toMin, toMax: toMax}
 
 	// Initialize current time


### PR DESCRIPTION
This PR cleans up some of the comments and rename `timeoutHandler` to `timeoutGenerator`.