### PR TITLE
Finalize leader, follower and candidate roles

### DIFF
--- a/src/datasources/mock_server_state_dao.go
+++ b/src/datasources/mock_server_state_dao.go
@@ -1,0 +1,40 @@
+package server_state_dao
+
+// testServerStateDao implements the ServerStateDao interface for use in unit
+// tests
+type testServerStateDao struct {
+	currentTerm int64
+	votedFor    int64
+}
+
+// MakeTestServerStateDao creates an instance of testServerStateDao for use
+// outside of this package
+func MakeTestServerStateDao() *testServerStateDao {
+	return &testServerStateDao{}
+}
+
+func (s *testServerStateDao) CurrentTerm() int64 {
+	return s.currentTerm
+}
+
+func (s *testServerStateDao) UpdateTerm(serverTerm int64) error {
+	s.currentTerm = serverTerm
+	s.votedFor = -1
+	return nil
+}
+
+func (s *testServerStateDao) UpdateTermVotedFor(serverTerm int64,
+	serverID int64) error {
+	s.currentTerm = serverTerm
+	s.votedFor = serverID
+	return nil
+}
+
+func (s *testServerStateDao) UpdateVotedFor(serverID int64) error {
+	s.votedFor = serverID
+	return nil
+}
+
+func (s *testServerStateDao) VotedFor() (int64, int64) {
+	return s.currentTerm, s.votedFor
+}

--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -1,38 +1,23 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/giulioborghesi/raft-implementation/src/utils"
+)
+
+const (
+	candidateErrFmt = "%s should not be called when a server is a candidate"
 )
 
 type candidateRole struct {
 	voteRequestorMaker func() voteRequestor
 }
 
-func (c *candidateRole) startElection(servers []string,
-	s *serverState) []chan requestVoteResult {
-	candidateTerm := s.currentTerm()
-	candidateID := s.serverID
-
-	// Request a vote from each server asynchronously
-	results := make([]chan requestVoteResult, 0, len(servers))
-	for _, server := range servers {
-		// Create vote requestor
-		r := c.voteRequestorMaker()
-		result := make(chan requestVoteResult)
-
-		// Request vote from server asynchronously
-		localServer := server
-		go func() {
-			result <- r.requestVote(localServer,
-				candidateTerm, candidateID)
-		}()
-		results = append(results, result)
-	}
-
-	// Return slice of results for each remote server
-	return results
+func (c *candidateRole) appendEntry(serverTerm int64, serverID int64,
+	s *serverState) (int64, bool) {
+	panic(fmt.Sprintf(candidateErrFmt, "appendEntry"))
 }
 
 func (c *candidateRole) finalizeElection(electionTerm int64,
@@ -73,4 +58,71 @@ func (c *candidateRole) finalizeElection(electionTerm int64,
 		s.role = leader
 		s.lastModified = time.Now()
 	}
+}
+
+func (l *candidateRole) makeCandidate(_ time.Duration, s *serverState) bool {
+	// Get current term
+	currentTerm := s.currentTerm()
+
+	// Update term, voted for and last modified
+	s.updateTermVotedFor(currentTerm+1, s.serverID)
+	s.lastModified = time.Now()
+	return true
+}
+
+func (c *candidateRole) makeFollower(serverTerm int64, s *serverState) bool {
+	// Get current term
+	currentTerm := s.currentTerm()
+
+	// Candidate remains candidate if server term less than current term
+	if currentTerm > serverTerm {
+		return false
+	}
+
+	// Change role to follower, update term and last modified
+	s.role = follower
+	s.updateTerm(serverTerm)
+	s.lastModified = time.Now()
+	return true
+}
+
+func (c *candidateRole) requestVote(serverTerm int64,
+	serverID int64, s *serverState) (int64, bool) {
+	// Get current term
+	currentTerm := s.currentTerm()
+	if currentTerm >= serverTerm {
+		return currentTerm, false
+	}
+
+	// Remote server has a term higher than current one, cast vote and convert
+	// to follower
+	s.role = follower
+	s.updateTermVotedFor(serverTerm, serverID)
+	s.lastModified = time.Now()
+	return serverTerm, true
+}
+
+func (c *candidateRole) startElection(servers []string,
+	s *serverState) []chan requestVoteResult {
+	candidateTerm := s.currentTerm()
+	candidateID := s.serverID
+
+	// Request a vote from each server asynchronously
+	results := make([]chan requestVoteResult, 0, len(servers))
+	for _, server := range servers {
+		// Create vote requestor
+		r := c.voteRequestorMaker()
+		result := make(chan requestVoteResult)
+
+		// Request vote from server asynchronously
+		localServer := server
+		go func() {
+			result <- r.requestVote(localServer,
+				candidateTerm, candidateID)
+		}()
+		results = append(results, result)
+	}
+
+	// Return slice of results for each remote server
+	return results
 }

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -1,189 +1,250 @@
 package domain
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
 const (
-	startingTerm     = 15
-	startingVotedFor = 0
+	testFollowerStartingTerm = 15
+	testFollowerVotedFor     = 1
+	testFollowerLeaderID     = 2
+	testFollowerRemoteID     = 4
 )
 
-// mockedServerStateDao is a server state DAO mack
-type mockedServerStateDao struct {
-	currentTerm int64
-	votedFor    int64
-}
+// MakeFollowerServerState creates and initializes an instance of serverState
+// for a server in follower mode
+func MakeFollowerServerState() *serverState {
+	dao := server_state_dao.MakeTestServerStateDao()
+	dao.UpdateTerm(testFollowerStartingTerm)
+	dao.UpdateVotedFor(testFollowerVotedFor)
 
-func (s *mockedServerStateDao) CurrentTerm() int64 {
-	return s.currentTerm
-}
-
-func (s *mockedServerStateDao) UpdateTerm(serverTerm int64) error {
-	s.currentTerm = serverTerm
-	s.votedFor = -1
-	return nil
-}
-
-func (s *mockedServerStateDao) UpdateTermVotedFor(serverTerm int64,
-	serverID int64) error {
-	s.currentTerm = serverTerm
-	s.votedFor = serverID
-	return nil
-}
-
-func (s *mockedServerStateDao) UpdateVotedFor(serverID int64) error {
-	s.votedFor = serverID
-	return nil
-}
-
-func (s *mockedServerStateDao) VotedFor() (int64, int64) {
-	return s.currentTerm, s.votedFor
-}
-
-func TestAppendEntry(t *testing.T) {
-	// Initialize mocked server state dao
-	dao := new(mockedServerStateDao)
-	dao.currentTerm = startingTerm
-	dao.votedFor = startingVotedFor
-
-	// Initialize server state
 	s := new(serverState)
 	s.dao = dao
+	s.leaderID = testFollowerLeaderID
+	return s
+}
 
-	// Instantiate follower
+func TestFollowerMethodsThatPanic(t *testing.T) {
+	// Initialize server state and follower
 	f := new(followerRole)
+	s := new(serverState)
 
-	// Server term is less than current term, append entry should fail
-	var serverTerm int64 = 10
-	var serverID int64 = 1
-	term, ok := f.appendEntry(serverTerm, serverID, s)
-	if term != startingTerm {
-		t.Errorf("wrong term following appendEntry: expected %d, actual %d",
-			startingTerm, term)
+	// Test finalizeElection
+	finalizeElection := func() {
+		f.finalizeElection(0, []requestVoteResult{}, s)
 	}
+	utils.AssertPanic(t, "finalizeElection", finalizeElection)
 
-	if ok {
-		t.Errorf("appendEntry succeded although it was expected to fail")
+	// Test startElection
+	startElection := func() {
+		f.startElection([]string{}, s)
 	}
+	utils.AssertPanic(t, "startElection", startElection)
+}
 
-	// Server term is greater than current term, append entry will succeed
-	serverTerm = 18
-	term, ok = f.appendEntry(serverTerm, serverID, s)
-	if term != serverTerm {
+func TestFollowerAppendEntry(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// Call toppendEntry should succeed
+	serverTerm := s.currentTerm()
+	actualterm, ok := f.appendEntry(serverTerm, s.leaderID, s)
+	if actualterm != serverTerm {
 		t.Errorf("wrong term following appendEntry: expected %d, actual %d",
-			serverTerm, term)
+			serverTerm, actualterm)
 	}
 
 	if !ok {
-		t.Errorf("appendEntry failed although it was expected to succeed")
+		t.Errorf("appendEntry was not expected to fail")
 	}
+
+	// Server term different from local value, appendEntry should panic
+	appendEntryInvalidTerm := func() {
+		f.appendEntry(serverTerm+1, s.leaderID, s)
+	}
+	utils.AssertPanic(t, "appendEntry", appendEntryInvalidTerm)
+
+	// Leader ID different from local value, appendEntry should panic
+	appendEntryInvalidLeaderID := func() {
+		f.appendEntry(serverTerm, s.leaderID+1, s)
+	}
+	utils.AssertPanic(t, "appendEntry", appendEntryInvalidLeaderID)
 }
 
-func TestMakeCandidate(t *testing.T) {
-	// Initialize mocked server state dao
-	dao := new(mockedServerStateDao)
-	dao.currentTerm = startingTerm
-	dao.votedFor = startingVotedFor
-
-	// Initialize server state
-	s := new(serverState)
-	s.dao = dao
-	s.lastModified = time.Now()
-	s.serverID = 2
-
-	// Instantiate follower
+func TestFollowerMakeCandidate(t *testing.T) {
+	// Create server state and follower instance
 	f := new(followerRole)
+	s := MakeFollowerServerState()
 
-	// Change server role to candidate
-	f.makeCandidate(time.Duration(0), s)
-	term, votedFor := s.votedFor()
-	if term != startingTerm+1 {
-		t.Errorf("wrong term following makeCandidate: expected %d, actual %d",
-			startingTerm+1, term)
+	// Store initial term for later comparison
+	initialTerm := s.currentTerm()
+
+	// Initialize time and duration
+	s.lastModified = time.Now()
+	to := time.Second
+	success := f.makeCandidate(to, s)
+
+	// Apart from patological cases during test execution, this should fail
+	if success {
+		t.Fatalf("makeCandidate was expected to fail")
 	}
 
-	if votedFor != 2 {
-		t.Errorf("vote should have been casted for local server")
+	if s.currentTerm() != initialTerm {
+		t.Fatalf("makeCandidate should not change the current term")
+	}
+
+	if s.role != follower {
+		t.Fatalf(fmt.Sprintf("invalid server role following makeCandidate: "+
+			"expected: %d, actual: %d", follower, s.role))
+	}
+
+	// Ensure time elapsed exceeds timeout
+	s.lastModified = time.Now().Add(-to)
+	success = f.makeCandidate(to, s)
+
+	if !success {
+		t.Fatalf("makeCandidate was expected to succeed")
 	}
 
 	if s.role != candidate {
-		t.Errorf("role should be candidate following makeCandidate")
+		t.Fatalf(fmt.Sprintf("invalid server role following makeCandidate: "+
+			"expected: %d, actual: %d", candidate, s.role))
 	}
 }
 
-func TestRequestVote(t *testing.T) {
-	// Initialize mocked server state dao
-	dao := new(mockedServerStateDao)
-	dao.currentTerm = startingTerm
-	dao.votedFor = startingVotedFor
-
-	// Initialize server state
-	s := new(serverState)
-	s.dao = dao
-
-	// Instantiate follower
+func TestFollowerPrepareAppend(t *testing.T) {
+	// Create server state and follower instance
 	f := new(followerRole)
+	s := MakeFollowerServerState()
 
-	// Server term is less than current term, request vote will fail
-	var serverTerm int64 = startingTerm - 2
-	var serverID int64 = 1
-	term, ok := f.requestVote(serverTerm, serverID, s)
-	if term != startingTerm {
-		t.Errorf("wrong term following requestVote: expected %d, actual %d",
-			startingTerm, term)
-	}
-
-	if ok {
-		t.Errorf("requestVote succeded although it was expected to fail")
-	}
-
-	// Server term is equal to current term but vote was already casted
-	serverTerm = startingTerm
-	term, ok = f.requestVote(serverTerm, serverID, s)
-	if term != startingTerm {
-		t.Errorf("wrong term following requestVote: expected %d, actual %d",
-			startingTerm, term)
-	}
-
-	if ok {
-		t.Errorf("requestVote succeded although it was expected to fail")
-	}
-
-	// Term is now updated and votedFor is reset to nil
-	serverTerm = startingTerm + 5
-	s.updateTerm(serverTerm)
-	term, votedFor := s.votedFor()
-	if term != serverTerm {
-		t.Errorf("wrong term following updateTerm: expected %d, actual %d",
-			serverTerm, term)
-	}
-
-	if votedFor != -1 {
-		t.Errorf("votedFor was not reset following updateTerm")
-	}
-
-	// requestVote should now succeed
-	term, ok = f.requestVote(serverTerm, serverID, s)
-	if term != serverTerm {
-		t.Errorf("wrong term returned by requestVote: expected %d, actual %d",
-			serverTerm, term)
-	}
-
+	// Call to prepareAppend expected to succeed
+	serverTerm := s.currentTerm()
+	ok := f.prepareAppend(serverTerm, s.leaderID, s)
 	if !ok {
-		t.Errorf("requestVote failed although it was expected to succeed")
+		t.Fatalf("prepareAppend expected to succeed")
 	}
 
-	// If server term is greater than current term, requestVote should succeed
-	serverTerm += 2
-	term, ok = f.requestVote(serverTerm, serverID, s)
-	if term != serverTerm {
-		t.Errorf("wrong term returned by requestVote: expected %d, actual %d",
-			serverTerm, term)
+	if s.currentTerm() != testFollowerStartingTerm {
+		t.Fatalf("prepareAppend should not change the current term")
 	}
 
+	// Server term less than local term, prepareAppend expected to fail
+	serverTerm = s.currentTerm() - 1
+	ok = f.prepareAppend(serverTerm, testFollowerRemoteID, s)
+	if ok {
+		t.Fatalf("prepareAppend expected to fail")
+	}
+
+	if s.currentTerm() != testFollowerStartingTerm {
+		t.Fatalf("prepareAppend should not change the current term")
+	}
+
+	// Server term exceeds local term, prepareAppend will succeed and leader
+	// ID will be updated
+	serverTerm = s.currentTerm() + 1
+	ok = f.prepareAppend(serverTerm, testFollowerRemoteID, s)
 	if !ok {
-		t.Errorf("requestVote failed although it was expected to succeed")
+		t.Fatalf("prepareAppend expected to succeed")
+	}
+
+	if s.currentTerm() != serverTerm {
+		t.Fatalf(fmt.Sprintf("invalid term after prepareAppend: "+
+			"expected: %d, actual: %d", serverTerm, s.currentTerm()))
+	}
+
+	if s.leaderID != testFollowerRemoteID {
+		t.Fatalf("leader ID expected to change")
+	}
+
+	// Cause a panic as result of multiple leaders present in the same term
+	prepareAppend := func() {
+		serverID := int64(testFollowerRemoteID - 1)
+		f.prepareAppend(serverTerm, serverID, s)
+	}
+	utils.AssertPanic(t, "prepareAppend", prepareAppend)
+}
+
+func TestFollowerRequestVote(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// Store initial term for further comparison
+	initialTerm := s.currentTerm()
+
+	// Already voted, return false
+	serverTerm := initialTerm
+	currentTerm, voted := f.requestVote(serverTerm, testFollowerRemoteID, s)
+
+	if currentTerm != initialTerm {
+		t.Fatalf("invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", initialTerm, currentTerm)
+	}
+
+	if s.currentTerm() != initialTerm {
+		t.Fatalf("currentTerm not expected to change")
+	}
+
+	if voted {
+		t.Fatalf("requestVote not expected to grant a vote")
+	}
+
+	if s.leaderID != testFollowerLeaderID {
+		t.Fatalf("invalid leader ID following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, s.leaderID)
+	}
+
+	// Server did not vote yet, grant vote and return true
+	s.updateVotedFor(invalidLeaderID)
+	currentTerm, voted = f.requestVote(serverTerm, testFollowerRemoteID, s)
+
+	if s.currentTerm() != initialTerm && currentTerm != initialTerm {
+		t.Fatalf("invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", initialTerm, currentTerm)
+	}
+
+	if !voted {
+		t.Fatalf("requestVote expected to grant a vote")
+	}
+
+	_, votedForID := s.votedFor()
+	if votedForID != testFollowerRemoteID {
+		t.Fatalf("votedFor invalid following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, votedForID)
+	}
+
+	if s.leaderID != testFollowerLeaderID {
+		t.Fatalf("invalid leader ID following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, s.leaderID)
+	}
+
+	// Server term exceeds local term, vote will be granted
+	serverTerm += 1
+	s.updateVotedFor(invalidLeaderID)
+	currentTerm, voted = f.requestVote(serverTerm, testFollowerRemoteID, s)
+	if s.currentTerm() != serverTerm && currentTerm != serverTerm {
+		t.Fatalf("invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", initialTerm, currentTerm)
+	}
+
+	if !voted {
+		t.Fatalf("requestVote expected to grant a vote")
+	}
+
+	_, votedForID = s.votedFor()
+	if votedForID != testFollowerRemoteID {
+		t.Fatalf("votedFor invalid following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, votedForID)
+	}
+
+	if s.leaderID != invalidLeaderID {
+		t.Fatalf("invalid leader ID following requestVote: "+
+			"expected: %d, actual: %d", invalidLeaderID, s.leaderID)
 	}
 }

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -6,61 +6,64 @@ import (
 )
 
 const (
-	leaderErrFmt = "%s should not be called when a server is a follower"
+	leaderErrMultFmt = "multiple leaders in the same term detected"
 )
 
 type leaderRole struct{}
 
 func (l *leaderRole) appendEntry(serverTerm int64,
 	serverID int64, s *serverState) (int64, bool) {
-	// Get current term
-	currentTerm := s.currentTerm()
-
-	// No two leaders can be elected during the same term
-	if currentTerm == serverTerm {
-		panic("cannot have more than one leader per term")
-	}
-
-	// If calling server term is greater than local server term, role should
-	// have been changed to follower: failure to do so points to a bug
-	if currentTerm < serverTerm {
-		panic("leader has not transitioned to follower before" +
-			"calling appendEntry")
-	}
-	return currentTerm, false
+	panic(fmt.Sprintf(roleErrCallFmt, "appendEntry", "leader"))
 }
 
 func (l *leaderRole) finalizeElection(_ int64, _ []requestVoteResult,
 	_ *serverState) {
-	panic(fmt.Sprintf(leaderErrFmt, "finalizeElection"))
+	panic(fmt.Sprintf(roleErrCallFmt, "finalizeElection", "leader"))
 }
 
 func (l *leaderRole) makeCandidate(_ time.Duration, s *serverState) bool {
+	// Leaders cannot transition to candidates
 	return false
 }
 
-func (l *leaderRole) makeFollower(serverTerm int64, s *serverState) bool {
+func (l *leaderRole) prepareAppend(serverTerm int64, serverID int64,
+	s *serverState) bool {
 	// Get current term
 	currentTerm := s.currentTerm()
 
-	// Leader remains leader if server term not greater than current term
-	if currentTerm >= serverTerm {
+	if currentTerm == serverTerm {
+		// Multiple leaders in the same term are not allowed
+		panic(fmt.Sprintf(leaderErrMultFmt))
+	} else if currentTerm > serverTerm {
+		// Request received from a former leader, reject it
 		return false
 	}
 
-	// Change role to follower, update term and last modified
+	// Request received from new leader, transition to follower
 	s.role = follower
 	s.updateTerm(serverTerm)
+	s.leaderID = serverID
 	s.lastModified = time.Now()
 	return true
 }
 
 func (l *leaderRole) requestVote(serverTerm int64, serverID int64,
 	s *serverState) (int64, bool) {
-	panic(fmt.Sprintf(leaderErrFmt, "requestVote"))
+	// Get current term
+	currentTerm := s.currentTerm()
+	if currentTerm >= serverTerm {
+		return currentTerm, false
+	}
+
+	// Server term greater than local term, cast vote and become follower
+	s.role = follower
+	s.updateTermVotedFor(serverTerm, serverID)
+	s.leaderID = invalidLeaderID
+	s.lastModified = time.Now()
+	return serverTerm, true
 }
 
 func (l *leaderRole) startElection(servers []string,
 	s *serverState) []chan requestVoteResult {
-	panic(fmt.Sprintf(leaderErrFmt, "startElection"))
+	panic(fmt.Sprintf(roleErrCallFmt, "startElection", "leader"))
 }

--- a/src/domain/leader_role_test.go
+++ b/src/domain/leader_role_test.go
@@ -1,0 +1,176 @@
+package domain
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/utils"
+)
+
+const (
+	testLeaderStartingTerm = 15
+	testLeaderVotedFor     = 1
+	testLeaderLeaderID     = 2
+	testLeaderRemoteID     = 4
+)
+
+// MakeLeaderServerState creates and initializes an instance of serverState
+// for a server in leader mode
+func MakeLeaderServerState() *serverState {
+	dao := server_state_dao.MakeTestServerStateDao()
+	dao.UpdateTerm(testLeaderStartingTerm)
+	dao.UpdateVotedFor(testLeaderVotedFor)
+
+	s := new(serverState)
+	s.dao = dao
+	s.leaderID = testLeaderLeaderID
+	s.role = leader
+	s.serverID = s.leaderID
+	return s
+}
+func TestLeaderMethodsThatPanic(t *testing.T) {
+	// Initialize server state and leader
+	l := new(leaderRole)
+	s := new(serverState)
+
+	// Test appendEntry
+	appendEntry := func() {
+		l.appendEntry(0, 0, s)
+	}
+	utils.AssertPanic(t, "appendEntry", appendEntry)
+
+	// Test finalizeElection
+	finalizeElection := func() {
+		l.finalizeElection(0, []requestVoteResult{}, s)
+	}
+	utils.AssertPanic(t, "finalizeElection", finalizeElection)
+
+	// Test startElection
+	startElection := func() {
+		l.startElection([]string{}, s)
+	}
+	utils.AssertPanic(t, "startElection", startElection)
+}
+
+func TestLeaderMakeCandidate(t *testing.T) {
+	// Create server state and leader instance
+	l := new(leaderRole)
+	s := MakeLeaderServerState()
+
+	// makeCandidate always returns false
+	success := l.makeCandidate(time.Millisecond, s)
+	if success {
+		t.Fatalf("makeCandidate did not return false")
+	}
+}
+
+func TestLeaderPrepareAppend(t *testing.T) {
+	// Create server state and leader instance
+	l := new(leaderRole)
+	s := MakeLeaderServerState()
+
+	// Store initial term
+	initialTerm := s.currentTerm()
+
+	// Initialize remote server term
+	remoteServerTerm := int64(initialTerm - 1)
+	remoteServerID := int64(s.leaderID + 1)
+
+	// Server term less than local term, prepareAppend should return false
+	success := l.prepareAppend(remoteServerTerm, remoteServerID, s)
+
+	if s.currentTerm() != initialTerm {
+		t.Fatalf("prepareAppend should not modify server term")
+	}
+
+	if success {
+		t.Fatalf("prepareAppend expected to return false")
+	}
+
+	// prepareAppend should change server role to follower and return true
+	remoteServerTerm = testLeaderStartingTerm + 1
+	success = l.prepareAppend(remoteServerTerm, remoteServerID, s)
+
+	if s.currentTerm() == initialTerm {
+		t.Fatalf("prepareAppend expected to modify server term")
+	}
+
+	if s.currentTerm() != remoteServerTerm {
+		t.Fatalf("invalid term following prepareAppend: "+
+			"expected: %d, actual: %d", remoteServerTerm, s.currentTerm())
+	}
+
+	if s.role != follower {
+		t.Fatalf("server did not transition to follower role")
+	}
+
+	if s.leaderID != remoteServerID {
+		t.Fatalf("invalid leader ID: expected: %d, actual: %d",
+			remoteServerID, s.leaderID)
+	}
+
+	if !success {
+		t.Fatalf("prepareAppend expected to return true")
+	}
+
+	// prepareAppend should panic when two leaders in same term are detected
+	prepareAppend := func() {
+		remoteServerTerm = s.currentTerm()
+		l.prepareAppend(remoteServerTerm, remoteServerID, s)
+	}
+	utils.AssertPanic(t, "prepareAppend", prepareAppend)
+}
+
+func TestLeaderRequestVote(t *testing.T) {
+	// Create server state and leader instance
+	l := new(leaderRole)
+	s := MakeLeaderServerState()
+
+	// Store initial term
+	initialTerm := s.currentTerm()
+
+	// Initialize remote server term
+	remoteServerTerm := int64(initialTerm - 1)
+	remoteServerID := int64(s.leaderID + 1)
+
+	// Server term less than local term, requestVote should return false
+	currentTerm, success := l.requestVote(remoteServerTerm,
+		remoteServerID, s)
+
+	if currentTerm != initialTerm && s.currentTerm() != initialTerm {
+		t.Fatalf(fmt.Sprintf("Invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", currentTerm, s.currentTerm()))
+	}
+
+	if success {
+		t.Fatalf("requestVote expected to return false")
+	}
+
+	// requestVote should change server role to follower and return true
+	remoteServerTerm = testLeaderStartingTerm + 1
+	currentTerm, success = l.requestVote(remoteServerTerm,
+		remoteServerID, s)
+
+	if currentTerm == initialTerm {
+		t.Fatalf("requestVote expected to modify server term")
+	}
+
+	if currentTerm != s.currentTerm() {
+		t.Fatalf("server term not correctly updated by requestVote")
+	}
+
+	if s.role != follower {
+		t.Fatalf("server did not transition to follower role")
+	}
+
+	if s.leaderID != invalidLeaderID {
+		t.Fatalf("invalid leader ID: expected: %d, actual: %d",
+			invalidLeaderID, s.leaderID)
+	}
+
+	if !success {
+		t.Fatalf("requestVote expected to return true")
+	}
+}

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -2,6 +2,10 @@ package domain
 
 import "time"
 
+const (
+	roleErrCallFmt = "%s should not be called when the server is a %s"
+)
+
 // serverRole defines the interface for a server's role in RAFT. There exists
 // three roles: follower, candidate and leader. Each role implements a distinct
 // behavior for the following endpoints: requestVote, appendEntry and
@@ -17,11 +21,13 @@ type serverRole interface {
 	// followers and leaders should raise a panic
 	finalizeElection(int64, []requestVoteResult, *serverState)
 
-	// makeFollower implements the role transition logic to follower
-	makeFollower(int64, *serverState) bool
-
 	// makeCandidate implements the role transition logic to candidate
 	makeCandidate(time.Duration, *serverState) bool
+
+	// prepareAppend prepares the server to respond to an AppendEntry RPC: it
+	// changes the server role to follower and updates the server term and
+	// leader ID if applicable
+	prepareAppend(int64, int64, *serverState) bool
 
 	// requestVote implements the logic used to determine whether a server
 	// should grant its vote to an external server for the current term

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -10,6 +10,8 @@ const (
 	follower = iota
 	leader
 	candidate
+
+	invalidLeaderID = 0
 )
 
 var (
@@ -34,6 +36,7 @@ type serverState struct {
 	lastModified time.Time
 	role         int
 	serverID     int64
+	leaderID     int64
 }
 
 // currentTerm returns the current term ID

--- a/src/utils/panic.go
+++ b/src/utils/panic.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	panicErrorMsg = "%s expected to panic"
+)
+
+func AssertPanic(t *testing.T, s string, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf(fmt.Sprintf(panicErrorMsg, s))
+		}
+	}()
+
+	f()
+}


### PR DESCRIPTION
This PR finalizes the implementations of `leaderRole`, `followerRole` and `candidateRole`. It also adds unit tests for `followerRole` and `candidateRole`