### PR TITLE
Implement entry appender

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/processout/grpc-go-pool v1.2.1
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/processout/grpc-go-pool v1.2.1 h1:hbp1BOA02CIxEAoRLHGpUhhPFv77nwfBLBeO3Ya9P7I=
+github.com/processout/grpc-go-pool v1.2.1/go.mod h1:F4hiNj96O6VQ87jv4rdz8R9tkHdelQQJ/J2B1a5VSt4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/src/clients/raft_client.go
+++ b/src/clients/raft_client.go
@@ -1,0 +1,55 @@
+package clients
+
+import (
+	"context"
+	"time"
+
+	"github.com/giulioborghesi/raft-implementation/src/service"
+	"github.com/giulioborghesi/raft-implementation/src/utils"
+	"google.golang.org/grpc"
+)
+
+const (
+	maxCount = 15
+)
+
+// AbstractRaftClient is a thin wrapper around around service.RaftClient. It
+// provides syntactic sugar to marshall / unmarshall RPC requests / responses
+type AbstractRaftClient interface {
+	AppendEntry(int64, int64, int64) (int64, bool)
+}
+
+// MakeRaftClient creates a new Raft client given a RPC connection and the
+// local server ID
+func MakeRaftClient(conn grpc.ClientConnInterface,
+	serverID int64) *raftClient {
+	c := new(raftClient)
+	c.client = service.NewRaftClient(conn)
+	c.serverID = serverID
+	return c
+}
+
+// raftClient implements the AbstractRaftClient interface
+type raftClient struct {
+	client   service.RaftClient
+	serverID int64
+}
+
+func (c *raftClient) AppendEntry(serverTerm int64,
+	logEntryTerm int64, logEntryIndex int64) (int64, bool) {
+	// Create RPC request
+	request := &service.AppendEntryRequest{ServerTerm: serverTerm,
+		ServerID: c.serverID}
+
+	// On error, request is retried using exponential back-off algorithm
+	count := 0
+	for {
+		reply, err := c.client.AppendEntry(context.Background(), request)
+		if err == nil {
+			return reply.CurrentTerm, reply.Success
+		}
+
+		time.Sleep(time.Millisecond * (1 << count))
+		count = utils.MaxInt(count+1, maxCount)
+	}
+}

--- a/src/domain/abstract_raft_service.go
+++ b/src/domain/abstract_raft_service.go
@@ -6,8 +6,20 @@ type AbstractRaftService interface {
 	// AppendEntry is the abstract method called by the AppendEntry RPC call
 	AppendEntry(remoteServerTerm int64, remoteServerID int64) (int64, bool)
 
+	// entryInfo returns the current leader term and the term of the log entry
+	// with the specified index
+	entryInfo(int64) (int64, int64)
+
+	// entries returns the log entries starting from the specified index, as
+	// well as the
+	entries(int64) ([]byte, int64, int64)
+
 	// lastModified returns the time of last server modification
 	lastModified() time.Time
+
+	// makeFollower changes the server role to follower if the term argument
+	// exceeds the current term
+	makeFollower(int64)
 
 	// RequestVote is the abstract method called by the RequestVote RPC call
 	RequestVote(remoteServerTerm int64, remoteServerID int64) (int64, bool)

--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -37,7 +37,7 @@ func (c *candidateRole) finalizeElection(electionTerm int64,
 		}
 
 		// Count votes received and determine max term seen
-		maxTerm = utils.MaxI64(maxTerm, result.serverTerm)
+		maxTerm = utils.MaxInt64(maxTerm, result.serverTerm)
 		if result.success {
 			count += 1
 		}
@@ -62,7 +62,7 @@ func (c *candidateRole) finalizeElection(electionTerm int64,
 	}
 }
 
-func (l *candidateRole) makeCandidate(_ time.Duration, s *serverState) bool {
+func (c *candidateRole) makeCandidate(_ time.Duration, s *serverState) bool {
 	// Get current term
 	currentTerm := s.currentTerm()
 

--- a/src/domain/candidate_role_test.go
+++ b/src/domain/candidate_role_test.go
@@ -1,0 +1,276 @@
+package domain
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/utils"
+)
+
+const (
+	testCandidateStartingTerm = 15
+	testCandidateVotedFor     = 1
+	testCandidateRemoteID     = 4
+	testCandidateServerID     = 2
+)
+
+// MakeCandidateServerState creates and initializes an instance of serverState
+// for a server in candidate mode
+func MakeCandidateServerState() *serverState {
+	dao := server_state_dao.MakeTestServerStateDao()
+	dao.UpdateTerm(testCandidateStartingTerm)
+	dao.UpdateVotedFor(testCandidateVotedFor)
+
+	s := new(serverState)
+	s.dao = dao
+	s.leaderID = invalidLeaderID
+	s.role = candidate
+	s.serverID = testCandidateServerID
+	return s
+}
+
+func TestCandidateMethodsThatPanic(t *testing.T) {
+	// Initialize server state and candidate
+	c := new(candidateRole)
+	s := new(serverState)
+
+	// Test finalizeElection
+	appendEntry := func() {
+		c.appendEntry(0, 0, s)
+	}
+	utils.AssertPanic(t, "appendEntry", appendEntry)
+}
+
+func TestCandidateMakeCandidate(t *testing.T) {
+	// Initialize server state and candidate
+	c := new(candidateRole)
+	s := MakeCandidateServerState()
+
+	// Store initial term
+	initialTerm := int64(testCandidateStartingTerm)
+
+	// makeCandidate will increase term and vote for itself
+	success := c.makeCandidate(time.Millisecond, s)
+
+	if !success {
+		t.Fatalf("makeCandidate expected to succeed")
+	}
+
+	if s.currentTerm() != initialTerm+1 {
+		t.Fatalf(fmt.Sprintf("invalid term: "+
+			"expected: %d, actual: %d", initialTerm+1, s.currentTerm()))
+	}
+
+	_, votedFor := s.votedFor()
+	if votedFor != testCandidateServerID {
+		t.Fatalf(fmt.Sprintf("invalid voted for: "+
+			"expected: %d, actual: %d", testCandidateServerID, votedFor))
+	}
+
+}
+
+/*
+func TestFollowerAppendEntry(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// Call toppendEntry should succeed
+	serverTerm := s.currentTerm()
+	actualterm, ok := f.appendEntry(serverTerm, s.leaderID, s)
+	if actualterm != serverTerm {
+		t.Errorf("wrong term following appendEntry: expected %d, actual %d",
+			serverTerm, actualterm)
+	}
+
+	if !ok {
+		t.Errorf("appendEntry was not expected to fail")
+	}
+
+	// Server term different from local value, appendEntry should panic
+	appendEntryInvalidTerm := func() {
+		f.appendEntry(serverTerm+1, s.leaderID, s)
+	}
+	utils.AssertPanic(t, "appendEntry", appendEntryInvalidTerm)
+
+	// Leader ID different from local value, appendEntry should panic
+	appendEntryInvalidLeaderID := func() {
+		f.appendEntry(serverTerm, s.leaderID+1, s)
+	}
+	utils.AssertPanic(t, "appendEntry", appendEntryInvalidLeaderID)
+}
+
+func TestFollowerMakeCandidate(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// Store initial term for later comparison
+	initialTerm := s.currentTerm()
+
+	// Initialize time and duration
+	s.lastModified = time.Now()
+	to := time.Second
+	success := f.makeCandidate(to, s)
+
+	// Apart from patological cases during test execution, this should fail
+	if success {
+		t.Fatalf("makeCandidate was expected to fail")
+	}
+
+	if s.currentTerm() != initialTerm {
+		t.Fatalf("makeCandidate should not change the current term")
+	}
+
+	if s.role != follower {
+		t.Fatalf(fmt.Sprintf("invalid server role following makeCandidate: "+
+			"expected: %d, actual: %d", follower, s.role))
+	}
+
+	// Ensure time elapsed exceeds timeout
+	s.lastModified = time.Now().Add(-to)
+	success = f.makeCandidate(to, s)
+
+	if !success {
+		t.Fatalf("makeCandidate was expected to succeed")
+	}
+
+	if s.role != candidate {
+		t.Fatalf(fmt.Sprintf("invalid server role following makeCandidate: "+
+			"expected: %d, actual: %d", candidate, s.role))
+	}
+}
+
+func TestFollowerPrepareAppend(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// Call to prepareAppend expected to succeed
+	serverTerm := s.currentTerm()
+	ok := f.prepareAppend(serverTerm, s.leaderID, s)
+	if !ok {
+		t.Fatalf("prepareAppend expected to succeed")
+	}
+
+	if s.currentTerm() != testFollowerStartingTerm {
+		t.Fatalf("prepareAppend should not change the current term")
+	}
+
+	// Server term less than local term, prepareAppend expected to fail
+	serverTerm = s.currentTerm() - 1
+	ok = f.prepareAppend(serverTerm, testFollowerRemoteID, s)
+	if ok {
+		t.Fatalf("prepareAppend expected to fail")
+	}
+
+	if s.currentTerm() != testFollowerStartingTerm {
+		t.Fatalf("prepareAppend should not change the current term")
+	}
+
+	// Server term exceeds local term, prepareAppend will succeed and leader
+	// ID will be updated
+	serverTerm = s.currentTerm() + 1
+	ok = f.prepareAppend(serverTerm, testFollowerRemoteID, s)
+	if !ok {
+		t.Fatalf("prepareAppend expected to succeed")
+	}
+
+	if s.currentTerm() != serverTerm {
+		t.Fatalf(fmt.Sprintf("invalid term after prepareAppend: "+
+			"expected: %d, actual: %d", serverTerm, s.currentTerm()))
+	}
+
+	if s.leaderID != testFollowerRemoteID {
+		t.Fatalf("leader ID expected to change")
+	}
+
+	// Cause a panic as result of multiple leaders present in the same term
+	prepareAppend := func() {
+		serverID := int64(testFollowerRemoteID - 1)
+		f.prepareAppend(serverTerm, serverID, s)
+	}
+	utils.AssertPanic(t, "prepareAppend", prepareAppend)
+}
+
+func TestFollowerRequestVote(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// Store initial term for further comparison
+	initialTerm := s.currentTerm()
+
+	// Already voted, return false
+	serverTerm := initialTerm
+	currentTerm, voted := f.requestVote(serverTerm, testFollowerRemoteID, s)
+
+	if currentTerm != initialTerm {
+		t.Fatalf("invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", initialTerm, currentTerm)
+	}
+
+	if s.currentTerm() != initialTerm {
+		t.Fatalf("currentTerm not expected to change")
+	}
+
+	if voted {
+		t.Fatalf("requestVote not expected to grant a vote")
+	}
+
+	if s.leaderID != testFollowerLeaderID {
+		t.Fatalf("invalid leader ID following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, s.leaderID)
+	}
+
+	// Server did not vote yet, grant vote and return true
+	s.updateVotedFor(invalidLeaderID)
+	currentTerm, voted = f.requestVote(serverTerm, testFollowerRemoteID, s)
+
+	if s.currentTerm() != initialTerm && currentTerm != initialTerm {
+		t.Fatalf("invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", initialTerm, currentTerm)
+	}
+
+	if !voted {
+		t.Fatalf("requestVote expected to grant a vote")
+	}
+
+	_, votedForID := s.votedFor()
+	if votedForID != testFollowerRemoteID {
+		t.Fatalf("votedFor invalid following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, votedForID)
+	}
+
+	if s.leaderID != testFollowerLeaderID {
+		t.Fatalf("invalid leader ID following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, s.leaderID)
+	}
+
+	// Server term exceeds local term, vote will be granted
+	serverTerm += 1
+	s.updateVotedFor(invalidLeaderID)
+	currentTerm, voted = f.requestVote(serverTerm, testFollowerRemoteID, s)
+	if s.currentTerm() != serverTerm && currentTerm != serverTerm {
+		t.Fatalf("invalid term returned by requestVote: "+
+			"expected: %d, actual: %d", initialTerm, currentTerm)
+	}
+
+	if !voted {
+		t.Fatalf("requestVote expected to grant a vote")
+	}
+
+	_, votedForID = s.votedFor()
+	if votedForID != testFollowerRemoteID {
+		t.Fatalf("votedFor invalid following requestVote: "+
+			"expected: %d, actual: %d", testFollowerLeaderID, votedForID)
+	}
+
+	if s.leaderID != invalidLeaderID {
+		t.Fatalf("invalid leader ID following requestVote: "+
+			"expected: %d, actual: %d", invalidLeaderID, s.leaderID)
+	}
+}
+*/

--- a/src/domain/entry_appender.go
+++ b/src/domain/entry_appender.go
@@ -1,0 +1,177 @@
+package domain
+
+import (
+	"sync"
+	"time"
+
+	"github.com/giulioborghesi/raft-implementation/src/clients"
+)
+
+var (
+	entryAppenderTimeout time.Duration = 50 * time.Millisecond
+)
+
+type abstractEntryAppender interface {
+	appendEntry(int64, int64)
+	start()
+	stop()
+}
+
+type entryAppender struct {
+	active                                     bool
+	matchIndex, nextIndex, logNextIndex        int64
+	appendTerm, lastAppendTerm, lastLeaderTerm int64
+
+	done    chan bool
+	client  clients.AbstractRaftClient
+	service AbstractRaftService
+	sync.Cond
+}
+
+func (a *entryAppender) appendEntry(appendTerm int64,
+	logNextIndex int64) {
+	a.L.Lock()
+	defer a.L.Unlock()
+
+	a.appendTerm = appendTerm
+	a.logNextIndex = logNextIndex
+	a.Signal()
+}
+
+func (a *entryAppender) processEntries() {
+	for a.active {
+		a.L.Lock()
+
+		// Must wait when term has expired or there is no entry to append
+		for a.appendTerm < a.lastLeaderTerm || (a.appendTerm ==
+			a.lastAppendTerm && (a.matchIndex+1) == a.logNextIndex) {
+			a.Wait()
+			if a.appendTerm >= a.lastLeaderTerm {
+				break
+			}
+		}
+
+		// Store append term and log index for later use
+		appendTerm := a.appendTerm
+		logNextIndex := a.logNextIndex
+		a.L.Unlock()
+
+		// Update the match index
+		if success := a.updateMatchIndex(appendTerm, logNextIndex); !success {
+			continue
+		}
+
+		// Fetch the log entries to send to the remote server
+		entries, leaderTerm, prevEntryTerm := a.service.entries(a.nextIndex)
+		if leaderTerm > a.lastLeaderTerm {
+			a.lastLeaderTerm = leaderTerm
+			continue
+		}
+
+		// Send the log entries to the remote server
+		a.sendEntries(a.matchIndex, prevEntryTerm, entries)
+	}
+}
+
+// updateMatchIndex finds the match index. This method performs non-trivial
+// work only when the current term exceeds the last known term
+func (a *entryAppender) updateMatchIndex(appendTerm int64,
+	logNextIndex int64) bool {
+	// Append term did not change from last append, nothing to do
+	if appendTerm == a.lastAppendTerm {
+		return true
+	}
+
+	// A new term has started, reset appender state
+	a.resetState(appendTerm, logNextIndex)
+
+	// Update match index
+	prevEntryIndex := a.nextIndex - 1
+	done := a.nextIndex == a.matchIndex+1
+	for !done {
+		leaderTerm, prevEntryTerm := a.service.entryInfo(prevEntryIndex)
+		if leaderTerm > appendTerm {
+			a.updateLeaderTerm(leaderTerm)
+			return false
+		}
+
+		// Send empty entry to remote server
+		if ok := a.sendEntries(prevEntryTerm, prevEntryIndex, nil); !ok {
+			return false
+		}
+
+		// Update loop condition
+		prevEntryIndex = a.nextIndex - 1
+		done = a.nextIndex == a.matchIndex+1
+	}
+	return true
+}
+
+func (a *entryAppender) resetState(appendTerm int64, nextIndex int64) {
+	a.lastAppendTerm = appendTerm
+	a.lastLeaderTerm = a.lastAppendTerm
+	a.matchIndex = 0
+	a.nextIndex = nextIndex
+}
+
+func (a *entryAppender) sendEntries(prevEntryTerm int64,
+	prevEntryIndex int64, entries []byte) bool {
+	// Send entries to remote server
+	remoteTerm, success := a.client.AppendEntry(a.lastAppendTerm,
+		prevEntryTerm, prevEntryIndex)
+
+	// Remote server term greater than local term, return
+	if remoteTerm > a.lastAppendTerm {
+		a.updateLeaderTerm(remoteTerm)
+		return false
+	}
+
+	// Update entry appender state and return
+	if success {
+		a.matchIndex = prevEntryIndex + int64(len(entries))
+		a.nextIndex = a.matchIndex + 1
+	} else {
+		a.nextIndex -= 1
+	}
+	return true
+}
+
+func (a *entryAppender) start() {
+	a.L.Lock()
+	defer a.L.Unlock()
+
+	// Nothing to do if appender is already active
+	if a.active {
+		return
+	}
+
+	// Create channel
+	done := make(chan bool)
+
+	// Launch process entries asynchronously
+	a.active = true
+	a.done = done
+	go func() {
+		a.processEntries()
+		done <- true
+	}()
+}
+
+func (a *entryAppender) stop() {
+	a.L.Lock()
+	defer a.L.Unlock()
+
+	// Nothing to do if appender is already inactive
+	if a.active == false {
+		return
+	}
+
+	// Set appender to inactive and wait for processEntries to return
+	a.active = false
+	<-a.done
+}
+
+func (a *entryAppender) updateLeaderTerm(newLeaderTerm int64) {
+	a.lastLeaderTerm = newLeaderTerm
+	a.service.makeFollower(newLeaderTerm)
+}

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -34,6 +34,28 @@ func (s *raftService) AppendEntry(remoteServerTerm int64,
 		remoteServerID, s.state)
 }
 
+func (s *raftService) entryInfo(entryIndex int64) (int64, int64) {
+	s.Lock()
+	defer s.Unlock()
+
+	term := s.state.currentTerm()
+	if entryIndex > 0 {
+		return term, invalidTermID
+	}
+	return s.state.currentTerm(), 0
+}
+
+func (s *raftService) makeFollower(leaderTerm int64) {
+	s.Lock()
+	defer s.Unlock()
+
+	term := s.state.currentTerm()
+	if term < leaderTerm {
+		s.state.updateTerm(leaderTerm)
+		s.state.role = follower
+	}
+}
+
 func (s *raftService) lastModified() time.Time {
 	// Lock access to server state
 	s.Lock()

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -12,6 +12,7 @@ const (
 	candidate
 
 	invalidLeaderID = 0
+	invalidTermID   = -1
 )
 
 var (

--- a/src/utils/math.go
+++ b/src/utils/math.go
@@ -1,7 +1,15 @@
 package utils
 
 // Max returns the maximum of two int64 values
-func MaxI64(x, y int64) int64 {
+func MaxInt64(x, y int64) int64 {
+	if x < y {
+		return y
+	}
+	return x
+}
+
+// Max returns the maximum of two int64 values
+func MaxInt(x, y int) int {
 	if x < y {
 		return y
 	}


### PR DESCRIPTION
This PR adds `entryAppender`. `entryAppender` is used to send `AppendEntriesRPC` to remote servers. 