### PR TITLE
Fix bug in prepare append logic

### DIFF
--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -56,18 +56,14 @@ func (f *followerRole) prepareAppend(serverTerm int64, serverID int64,
 		return false
 	}
 
-	// Update term and leader ID if a new leader is detected
+	// If term changed, set votedFor to invalid server ID
+	_, votedFor := s.votedFor()
 	if currentTerm < serverTerm {
-		s.updateTerm(serverTerm)
-		s.leaderID = serverID
+		votedFor = invalidServerID
 	}
 
-	// If leader is known, it must be equal to serverID
-	if s.leaderID == invalidServerID {
-		s.leaderID = serverID
-	} else if s.leaderID != serverID {
-		panic(fmt.Sprintf(followerErrIdFmt, s.leaderID, serverID))
-	}
+	// Update server state and return
+	s.updateServerState(follower, serverTerm, votedFor, serverID)
 	return true
 }
 

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -162,13 +162,19 @@ func TestFollowerPrepareAppend(t *testing.T) {
 	if s.leaderID != testFollowerRemoteID {
 		t.Fatalf("leader ID expected to change")
 	}
+}
 
-	// Cause a panic as result of multiple leaders present in the same term
-	prepareAppend := func() {
-		serverID := int64(testFollowerRemoteID - 1)
-		f.prepareAppend(serverTerm, serverID, s)
+func TestFollowerProcessAppendEntryEvent(t *testing.T) {
+	// Create server state and follower instance
+	f := new(followerRole)
+	s := MakeFollowerServerState()
+
+	// processAppendEntryEvent should always return false
+	ok := f.processAppendEntryEvent(0, 0, 0, s)
+	if ok {
+		t.Fatalf("processAppendEntryEvent expected to return false")
 	}
-	utils.AssertPanic(t, "prepareAppend", prepareAppend)
+
 }
 
 func TestFollowerRequestVote(t *testing.T) {

--- a/src/domain/timeout_generator_test.go
+++ b/src/domain/timeout_generator_test.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -22,9 +21,7 @@ func lastModified() time.Time {
 }
 
 func timeOutHandler(time.Duration) {
-	fmt.Println("Called!")
 	count++
-	fmt.Println(count)
 }
 
 func TestRandomDuration(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug in the `prepareAppend` logic for the `follower` role: specifically, it updates the time of last modification should `prepareAppend` succeed. It also modifies the existing code to use the `updateServerState` method of `serverState`.