### PR TITLE
Add heartbeat endpoint and its implementation in raftService and serverRole

### DIFF
--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -100,6 +100,10 @@ func (c *candidateRole) requestVote(serverTerm int64,
 	return serverTerm, true
 }
 
+func (c *candidateRole) sendHeartbeat(_ time.Duration, _ *serverState) {
+	return
+}
+
 func (c *candidateRole) startElection(servers []string,
 	s *serverState) []chan requestVoteResult {
 	candidateTerm := s.currentTerm()

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -91,6 +91,10 @@ func (f *followerRole) requestVote(serverTerm int64,
 	return serverTerm, true
 }
 
+func (f *followerRole) sendHeartbeat(_ time.Duration, _ *serverState) {
+	return
+}
+
 func (f *followerRole) startElection(servers []string,
 	s *serverState) []chan requestVoteResult {
 	panic(fmt.Sprintf(roleErrCallFmt, "startElection", "follower"))

--- a/src/domain/raft_log.go
+++ b/src/domain/raft_log.go
@@ -9,6 +9,9 @@ type logEntry struct {
 // abstractRaftLog specifies the interface to be exposed by a log in Raft
 type abstractRaftLog interface {
 	appendEntries([]*logEntry, int64, int64) bool
+
+	// nextIndex returns the index of the last log entry plus one
+	nextIndex() int64
 }
 
 // mockRaftLog implements a mock log to be used for unit testing purposes
@@ -18,4 +21,8 @@ type mockRaftLog struct {
 
 func (l *mockRaftLog) appendEntries(_ []*logEntry, _ int64, _ int64) bool {
 	return l.value
+}
+
+func (l *mockRaftLog) nextIndex() int64 {
+	return 1
 }

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -34,6 +34,9 @@ type AbstractRaftService interface {
 	// RequestVote handles an incoming RequestVote RPC call
 	RequestVote(remoteServerTerm int64, remoteServerID int64) (int64, bool)
 
+	// sendHeartbeat exposes an endpoint to send heartbeats to followers
+	sendHeartbeat(time.Duration)
+
 	// StartElection initiates an election if the time elapsed since the last
 	// server update exceeds the election timeout
 	StartElection(time.Duration)
@@ -112,6 +115,14 @@ func (s *raftService) RequestVote(remoteServerTerm int64,
 	// Grant vote if possible
 	return s.roles[s.state.role].requestVote(remoteServerTerm,
 		remoteServerID, s.state)
+}
+
+func (s *raftService) sendHeartbeat(to time.Duration) {
+	// Lock access to server state
+	s.Lock()
+	defer s.Unlock()
+
+	s.roles[s.state.role].sendHeartbeat(to, s.state)
 }
 
 func (s *raftService) StartElection(to time.Duration) {

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -37,6 +37,10 @@ type serverRole interface {
 	// should grant its vote to an external server or not
 	requestVote(int64, int64, *serverState) (int64, bool)
 
+	// sendHeartbeat implements the logic to send an heartbeat message to
+	// followers
+	sendHeartbeat(time.Duration, *serverState)
+
 	// startElection starts an election. Only candidates can start an election
 	// and be elected: a panic occurs if leaders and followers call this method
 	startElection(servers []string, s *serverState) []chan requestVoteResult

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -64,6 +64,16 @@ func (s *serverState) updateCommitIndex(matchIndices []int64) {
 	s.commitIndex = utils.MaxInt64(s.commitIndex, indices[k])
 }
 
+// updateServerState updates the server state according to the provided
+// parameters
+func (s *serverState) updateServerState(newRole int, newTerm int64,
+	newVotedFor int64, newLeaderID int64) {
+	s.role = newRole
+	s.updateTermVotedFor(newTerm, newVotedFor)
+	s.leaderID = newLeaderID
+	s.lastModified = time.Now()
+}
+
 func (s *serverState) updateTerm(serverTerm int64) {
 	if err := s.dao.UpdateTerm(serverTerm); err != nil {
 		panic(err)
@@ -90,14 +100,4 @@ func (s *serverState) updateVotedFor(serverID int64) {
 // this server's vote during this term
 func (s *serverState) votedFor() (int64, int64) {
 	return s.dao.VotedFor()
-}
-
-// updateServerState updates the server state according to the provided
-// parameters
-func (s *serverState) updateServerState(newRole int, newTerm int64,
-	newVotedFor int64, newLeaderID int64) {
-	s.role = newRole
-	s.updateTermVotedFor(newTerm, newVotedFor)
-	s.leaderID = newLeaderID
-	s.lastModified = time.Now()
 }


### PR DESCRIPTION
This PR adds an heartbeat endpoint in `raftService` and implements its business logic for each server role. Both followers and candidates will ignore the request; leaders, on the other hand, will first check whether the timeout is still valid - e.g. nothing has occurred since the timeout expired - and then send an heartbeat message to the remote server.