### PR TITLE
Add Raft service integration test

### DIFF
--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -54,9 +54,7 @@ func (c *candidateRole) finalizeElection(electionTerm int64,
 	// Election is won if count of votes received is more than half of servers
 	// in the cluster
 	if count > ((1 + len(results)) / 2) {
-		s.role = leader
-		s.leaderID = s.serverID
-		s.lastModified = time.Now()
+		s.updateServerState(leader, maxTerm, s.serverID, s.serverID)
 	}
 }
 
@@ -121,7 +119,7 @@ func (c *candidateRole) startElection(
 		}()
 
 		// Append result to output list
-		results = append(results)
+		results = append(results, result)
 	}
 
 	// Return slice of results for each remote server

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -95,7 +95,7 @@ func (f *followerRole) sendHeartbeat(_ time.Duration, _ *serverState) {
 	return
 }
 
-func (f *followerRole) startElection(servers []string,
+func (f *followerRole) startElection(
 	s *serverState) []chan requestVoteResult {
 	panic(fmt.Sprintf(roleErrCallFmt, "startElection", "follower"))
 }

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -43,7 +43,7 @@ func TestFollowerMethodsThatPanic(t *testing.T) {
 
 	// Test startElection
 	startElection := func() {
-		f.startElection([]string{}, s)
+		f.startElection(s)
 	}
 	utils.AssertPanic(t, "startElection", startElection)
 }

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"container/list"
 	"fmt"
 	"time"
 )
@@ -12,9 +11,8 @@ const (
 
 // leaderRole implements the serverRole interface for a leader server
 type leaderRole struct {
-	replicators   []abstractEntryReplicator
-	appendResults *list.List
-	matchIndices  []int64
+	replicators  []abstractEntryReplicator
+	matchIndices []int64
 }
 
 func (l *leaderRole) appendEntry(_ []*logEntry, _, _, _, _, _ int64,
@@ -97,7 +95,7 @@ func (l *leaderRole) sendHeartbeat(to time.Duration, s *serverState) {
 	}
 }
 
-func (l *leaderRole) startElection(servers []string,
+func (l *leaderRole) startElection(
 	s *serverState) []chan requestVoteResult {
 	panic(fmt.Sprintf(roleErrCallFmt, "startElection", "leader"))
 }

--- a/src/domain/leader_role_test.go
+++ b/src/domain/leader_role_test.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"container/list"
 	"fmt"
 	"testing"
 	"time"
@@ -35,7 +34,6 @@ func TestLeaderMethodsThatPanic(t *testing.T) {
 	// Initialize server state and leader
 	l := new(leaderRole)
 	s := new(serverState)
-	l.appendResults = new(list.List)
 
 	// Test appendEntry
 	appendEntry := func() {
@@ -51,7 +49,7 @@ func TestLeaderMethodsThatPanic(t *testing.T) {
 
 	// Test startElection
 	startElection := func() {
-		l.startElection([]string{}, s)
+		l.startElection(s)
 	}
 	utils.AssertPanic(t, "startElection", startElection)
 }
@@ -60,7 +58,6 @@ func TestLeaderMakeCandidate(t *testing.T) {
 	// Create server state and leader instance
 	l := new(leaderRole)
 	s := MakeLeaderServerState()
-	l.appendResults = new(list.List)
 
 	// makeCandidate always returns false
 	success := l.makeCandidate(time.Millisecond, s)
@@ -73,7 +70,6 @@ func TestLeaderPrepareAppend(t *testing.T) {
 	// Create server state and leader instance
 	l := new(leaderRole)
 	s := MakeLeaderServerState()
-	l.appendResults = new(list.List)
 
 	// Store initial term
 	initialTerm := s.currentTerm()
@@ -131,7 +127,6 @@ func TestLeaderRequestVote(t *testing.T) {
 	// Create server state and leader instance
 	l := new(leaderRole)
 	s := MakeLeaderServerState()
-	l.appendResults = new(list.List)
 
 	// Store initial term
 	initialTerm := s.currentTerm()

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -85,6 +85,10 @@ func (s *raftService) entryInfo(entryIndex int64) (int64, int64) {
 	return s.state.currentTerm(), 0
 }
 
+func (s *raftService) entries(int64) ([]*logEntry, int64, int64) {
+	panic("method not implemented yet")
+}
+
 func (s *raftService) lastModified() time.Time {
 	// Lock access to server state
 	s.Lock()

--- a/src/domain/raft_service_integration_test.go
+++ b/src/domain/raft_service_integration_test.go
@@ -1,0 +1,64 @@
+package domain
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+)
+
+func createMockRaftService(vr []abstractVoteRequestor,
+	er []abstractEntryReplicator) *raftService {
+	// Create and initialize server state
+	s := new(serverState)
+	s.dao = server_state_dao.MakeTestServerStateDao()
+	s.role = follower
+	s.commitIndex = 0
+	s.serverID = 0
+	s.leaderID = 1
+	s.lastModified = time.Now()
+
+	// Create and initialize Raft service
+	service := &raftService{state: s, roles: make(map[int]serverRole)}
+	service.roles[follower] = &followerRole{}
+	service.roles[candidate] = &candidateRole{voteRequestors: vr}
+	service.roles[leader] = &leaderRole{replicators: er,
+		matchIndices: []int64{math.MaxInt64, 0}}
+	return service
+}
+
+func TestLeaderElection(t *testing.T) {
+	// Create service
+	vr := []abstractVoteRequestor{&mockVoteRequestor{maxCount: 1}}
+	s := createMockRaftService(vr, nil)
+
+	// Store initial term
+	initialTerm := s.state.currentTerm()
+
+	// Force new election - election expected to fail
+	d := time.Since(s.lastModified())
+	s.StartElection(d)
+
+	if s.state.role != candidate {
+		t.Fatalf("server expected to transition to candidate")
+	}
+
+	if s.state.currentTerm() != (initialTerm + 1) {
+		t.Fatalf("invalid term: expected: %d, actual: %d",
+			initialTerm, s.state.currentTerm())
+	}
+
+	// Force yet a new election - this time election will succeed
+	d = time.Since(s.lastModified())
+	s.StartElection(d)
+
+	if s.state.role != leader {
+		t.Fatalf("server expected to transition to leader")
+	}
+
+	if s.state.currentTerm() != (initialTerm + 2) {
+		t.Fatalf("invalid term: expected: %d, actual: %d",
+			initialTerm, s.state.currentTerm())
+	}
+}

--- a/src/domain/raft_service_integration_test.go
+++ b/src/domain/raft_service_integration_test.go
@@ -8,16 +8,17 @@ import (
 	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
 )
 
+const (
+	testServiceIntegrationLeaderID      = 1
+	testServiceIntegrationOtherServerID = 2
+)
+
 func createMockRaftService(vr []abstractVoteRequestor,
 	er []abstractEntryReplicator) *raftService {
-	// Create and initialize server state
-	s := new(serverState)
-	s.dao = server_state_dao.MakeTestServerStateDao()
-	s.role = follower
-	s.commitIndex = 0
-	s.serverID = 0
-	s.leaderID = 1
-	s.lastModified = time.Now()
+	// Create a server state instance
+	dao := server_state_dao.MakeTestServerStateDao()
+	log := &mockRaftLog{value: true}
+	s := makeServerState(dao, log, testServiceIntegrationLeaderID)
 
 	// Create and initialize Raft service
 	service := &raftService{state: s, roles: make(map[int]serverRole)}
@@ -28,15 +29,53 @@ func createMockRaftService(vr []abstractVoteRequestor,
 	return service
 }
 
+func TestLeaderAppendEntry(t *testing.T) {
+	// Create service
+	s := createMockRaftService(nil, nil)
+	s.state.updateTerm(s.state.currentTerm() + 1)
+	s.state.role = leader
+
+	// Store initial term
+	initialTerm := s.state.currentTerm()
+
+	// Server receives append entry request from previous leader
+	newTerm, success := s.AppendEntry(nil, initialTerm-1,
+		testServiceIntegrationOtherServerID, 0, 0, 0)
+
+	if newTerm != initialTerm {
+		t.Fatalf("invalid term returned by AppendEntry: "+
+			"expected: %d, actual: %d", initialTerm, newTerm)
+	}
+
+	if success {
+		t.Fatalf("call to AppendEntry was expected to fail")
+	}
+
+	// Server receives append entry request from new leader
+	newTerm, success = s.AppendEntry(nil, initialTerm+1,
+		testServiceIntegrationOtherServerID, 0, 0, 0)
+
+	if newTerm != initialTerm+1 {
+		t.Fatalf("invalid term returned by AppendEntry: "+
+			"expected: %d, actual: %d", initialTerm+1, newTerm)
+	}
+
+	if !success {
+		t.Fatalf("call to AppendEntry was expected to succeed")
+	}
+
+}
+
 func TestLeaderElection(t *testing.T) {
 	// Create service
-	vr := []abstractVoteRequestor{&mockVoteRequestor{maxCount: 1}}
+	vr := []abstractVoteRequestor{&mockVoteRequestor{maxCount: 1},
+		&mockVoteRequestor{maxCount: 2}}
 	s := createMockRaftService(vr, nil)
 
 	// Store initial term
 	initialTerm := s.state.currentTerm()
 
-	// Force new election - election expected to fail
+	// Force new election. Election is expected to fail
 	d := time.Since(s.lastModified())
 	s.StartElection(d)
 
@@ -44,17 +83,27 @@ func TestLeaderElection(t *testing.T) {
 		t.Fatalf("server expected to transition to candidate")
 	}
 
+	if s.state.leaderID != invalidServerID {
+		t.Fatalf("unexpected leader ID: expected: %d, actual: %d",
+			invalidServerID, s.state.leaderID)
+	}
+
 	if s.state.currentTerm() != (initialTerm + 1) {
 		t.Fatalf("invalid term: expected: %d, actual: %d",
 			initialTerm, s.state.currentTerm())
 	}
 
-	// Force yet a new election - this time election will succeed
+	// Force another election. Election is expected to succeed
 	d = time.Since(s.lastModified())
 	s.StartElection(d)
 
 	if s.state.role != leader {
 		t.Fatalf("server expected to transition to leader")
+	}
+
+	if s.state.leaderID != testServiceIntegrationLeaderID {
+		t.Fatalf("unexpected leader ID: expected: %d, actual: %d",
+			testServiceIntegrationLeaderID, s.state.leaderID)
 	}
 
 	if s.state.currentTerm() != (initialTerm + 2) {

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -17,20 +17,18 @@ const (
 	invalidTermID   = -1
 )
 
-var (
-	// Only one instance of serverState per server should exist
-	uniqueServerState *serverState
-)
-
-func init() {
-	uniqueServerState = new(serverState)
-	uniqueServerState.lastModified = time.Now()
-	uniqueServerState.role = follower
-}
-
-// getServerState returns a pointer to the unique instance of serverState
-func getServerState() *serverState {
-	return uniqueServerState
+// makeServerState creates a serverState instance
+func makeServerState(dao server_state_dao.ServerStateDao,
+	log abstractRaftLog, serverID int64) *serverState {
+	s := new(serverState)
+	s.dao = dao
+	s.log = log
+	s.lastModified = time.Now()
+	s.role = follower
+	s.commitIndex = 0
+	s.leaderID = invalidServerID
+	s.serverID = serverID
+	return s
 }
 
 // serverState encapsulates the state of a Raft server

--- a/src/domain/vote_requestor.go
+++ b/src/domain/vote_requestor.go
@@ -27,10 +27,20 @@ type abstractVoteRequestor interface {
 	requestVote(int64, int64) requestVoteResult
 }
 
-// makeVoteRequestor creates an object of type voteRequestor, intialized with a
-// provided client, and returns a pointer to it to the caller
-func makeVoteRequestor(c clients.AbstractRaftClient) abstractVoteRequestor {
-	return &voteRequestor{client: c}
+// mockVoteRequestor implements a mock vote requestor that will return false
+// for a configurable number of times, after which it will return true
+type mockVoteRequestor struct {
+	count, maxCount int
+}
+
+func (v *mockVoteRequestor) requestVote(serverTerm,
+	_ int64) requestVoteResult {
+	if v.count < v.maxCount {
+		v.count++
+		return requestVoteResult{serverTerm: serverTerm, success: false,
+			err: nil}
+	}
+	return requestVoteResult{serverTerm: serverTerm, success: true, err: nil}
 }
 
 // voteRequestor implements the abstractVoteRequestor interface. voteRequestor
@@ -38,6 +48,12 @@ func makeVoteRequestor(c clients.AbstractRaftClient) abstractVoteRequestor {
 // responsibility is limited to marshalling / unmarshalling the input / output
 type voteRequestor struct {
 	client clients.AbstractRaftClient
+}
+
+// makeVoteRequestor creates an object of type voteRequestor, intialized with a
+// provided client, and returns a pointer to it to the caller
+func makeVoteRequestor(c clients.AbstractRaftClient) abstractVoteRequestor {
+	return &voteRequestor{client: c}
 }
 
 func (v *voteRequestor) requestVote(serverTerm int64,


### PR DESCRIPTION
This PR adds an integration test for testing the functionalities of the `raftService` class. The integration test still relies on mock objects for some components, and its main goal is to check the interaction between the `raftService` class and the various `serverRole` classes. The test is not complete yet, and will be updated over time.