### PR TITLE
Implement Raft service client endpoints

### DIFF
--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -17,13 +17,13 @@ func (c *candidateRole) appendEntry(_ []*logEntry, _, _, _, _, _ int64,
 	panic(fmt.Sprintf(roleErrCallFmt, "appendEntry", "candidate"))
 }
 
-func (c *candidateRole) appendNewEntry(_ *logEntry,
+func (c *candidateRole) appendNewEntry(_ *logEntry, _ int64,
 	s *serverState) (string, int64, error) {
 	return "", s.leaderID, fmt.Errorf(wrongRoleErrFmt, "candidate")
 }
 
-func (c *candidateRole) entryStatus(_ string, s *serverState) (logEntryStatus,
-	int64, error) {
+func (c *candidateRole) entryStatus(_ string, _ int64,
+	s *serverState) (logEntryStatus, int64, error) {
 	return invalid, s.leaderID, fmt.Errorf(wrongRoleErrFmt, "candidate")
 }
 
@@ -104,7 +104,7 @@ func (c *candidateRole) requestVote(serverTerm int64,
 	return serverTerm, true
 }
 
-func (c *candidateRole) sendHeartbeat(_ time.Duration, _ *serverState) {
+func (c *candidateRole) sendHeartbeat(time.Duration, int64, *serverState) {
 	return
 }
 

--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -7,10 +7,6 @@ import (
 	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
-const (
-	candidateErrFmt = "%s should not be called when a server is a candidate"
-)
-
 // candidateRole implements the serverRole interface for a candidate server
 type candidateRole struct {
 	voteRequestors []abstractVoteRequestor
@@ -18,7 +14,17 @@ type candidateRole struct {
 
 func (c *candidateRole) appendEntry(_ []*logEntry, _, _, _, _, _ int64,
 	s *serverState) (int64, bool) {
-	panic(fmt.Sprintf(candidateErrFmt, "appendEntry"))
+	panic(fmt.Sprintf(roleErrCallFmt, "appendEntry", "candidate"))
+}
+
+func (c *candidateRole) appendNewEntry(_ *logEntry,
+	s *serverState) (string, int64, error) {
+	return "", s.leaderID, fmt.Errorf(wrongRoleErrFmt, "candidate")
+}
+
+func (c *candidateRole) entryStatus(_ string, s *serverState) (logEntryStatus,
+	int64, error) {
+	return invalid, s.leaderID, fmt.Errorf(wrongRoleErrFmt, "candidate")
 }
 
 func (c *candidateRole) finalizeElection(electionTerm int64,

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -30,13 +30,13 @@ func (f *followerRole) appendEntry(entries []*logEntry, serverTerm, serverID,
 	return currentTerm, s.log.appendEntries(entries, prevLogTerm, prevLogIndex)
 }
 
-func (f *followerRole) appendNewEntry(_ *logEntry,
+func (f *followerRole) appendNewEntry(_ *logEntry, _ int64,
 	s *serverState) (string, int64, error) {
 	return "", s.leaderID, fmt.Errorf(wrongRoleErrFmt, "follower")
 }
 
-func (f *followerRole) entryStatus(_ string, s *serverState) (logEntryStatus,
-	int64, error) {
+func (f *followerRole) entryStatus(_ string, _ int64,
+	s *serverState) (logEntryStatus, int64, error) {
 	return invalid, s.leaderID, fmt.Errorf(wrongRoleErrFmt, "follower")
 }
 
@@ -101,7 +101,7 @@ func (f *followerRole) requestVote(serverTerm int64,
 	return serverTerm, true
 }
 
-func (f *followerRole) sendHeartbeat(_ time.Duration, _ *serverState) {
+func (f *followerRole) sendHeartbeat(time.Duration, int64, *serverState) {
 	return
 }
 

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -27,7 +27,11 @@ func (f *followerRole) appendEntry(entries []*logEntry, serverTerm, serverID,
 	}
 
 	// Try appending log entries to log
-	return currentTerm, s.log.appendEntries(entries, prevLogTerm, prevLogIndex)
+	success := s.log.appendEntries(entries, prevLogTerm, prevLogIndex)
+	if success {
+		s.targetCommitIndex = commitIndex
+	}
+	return currentTerm, success
 }
 
 func (f *followerRole) appendNewEntry(_ *logEntry, _ int64,

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -30,6 +30,16 @@ func (f *followerRole) appendEntry(entries []*logEntry, serverTerm, serverID,
 	return currentTerm, s.log.appendEntries(entries, prevLogTerm, prevLogIndex)
 }
 
+func (f *followerRole) appendNewEntry(_ *logEntry,
+	s *serverState) (string, int64, error) {
+	return "", s.leaderID, fmt.Errorf(wrongRoleErrFmt, "follower")
+}
+
+func (f *followerRole) entryStatus(_ string, s *serverState) (logEntryStatus,
+	int64, error) {
+	return invalid, s.leaderID, fmt.Errorf(wrongRoleErrFmt, "follower")
+}
+
 func (f *followerRole) finalizeElection(_ int64, _ []requestVoteResult,
 	_ *serverState) {
 	panic(fmt.Sprintf(roleErrCallFmt, "finalizeElection", "follower"))

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -2,12 +2,41 @@ package domain
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
 const (
 	leaderErrMultFmt = "multiple leaders in the same term detected"
 )
+
+// encodeEntry creates a unique key for a newly inserted log entry by combining
+// the log term with the log index
+func encodeEntry(entryTerm int64, entryIndex int64) string {
+	return fmt.Sprintf("%d#%d", entryTerm, entryIndex)
+}
+
+// decodeEntry decodes a log entry unique key and returns the corresponding log
+// term and log entry index
+func decodeEntry(key string) (int64, int64) {
+	idx := strings.LastIndex(key, "#")
+
+	// Extract entry term
+	entryTerm, err := strconv.Atoi(key[:idx])
+	if err != nil {
+		panic(fmt.Errorf("decodeEntry: %v", err))
+	}
+
+	// Extract entry index
+	entryIndex, err := strconv.Atoi(key[idx+1:])
+	if err != nil {
+		panic(fmt.Errorf("decodeEntry: %v", err))
+	}
+
+	// Return decoded entry term and index
+	return int64(entryTerm), int64(entryIndex)
+}
 
 // leaderRole implements the serverRole interface for a leader server
 type leaderRole struct {
@@ -18,6 +47,40 @@ type leaderRole struct {
 func (l *leaderRole) appendEntry(_ []*logEntry, _, _, _, _, _ int64,
 	s *serverState) (int64, bool) {
 	panic(fmt.Sprintf(roleErrCallFmt, "appendEntry", "leader"))
+}
+
+func (l *leaderRole) appendNewEntry(entry *logEntry, commitIndex int64,
+	s *serverState) (string, int64, error) {
+	// Append new entry to log
+	nextLogIndex := s.log.appendEntry(entry)
+
+	// Replicate log entry and return unique entry key to client
+	l.sendEntries(s.currentTerm(), nextLogIndex, commitIndex, s)
+	return encodeEntry(s.currentTerm(), nextLogIndex), s.leaderID, nil
+}
+
+func (l *leaderRole) entryStatus(key string, commitIndex int64,
+	s *serverState) (logEntryStatus, int64, error) {
+	// Decode log entry key
+	logNextIndex := s.log.nextIndex()
+	entryTerm, entryIndex := decodeEntry(key)
+
+	// Entry must be a valid one
+	if entryTerm > s.currentTerm() || entryIndex > logNextIndex {
+		return invalid, s.leaderID, fmt.Errorf("entry is not valid")
+	}
+
+	// Entry is lost if a term mismatch is detected
+	actualEntryTerm := s.log.entryTerm(entryIndex)
+	if entryTerm != actualEntryTerm {
+		return lost, s.leaderID, nil
+	}
+
+	// Entry is committed if its index is at most the commit index
+	if entryIndex <= commitIndex {
+		return committed, s.leaderID, nil
+	}
+	return appended, s.leaderID, nil
 }
 
 func (l *leaderRole) finalizeElection(_ int64, _ []requestVoteResult,
@@ -53,7 +116,7 @@ func (l *leaderRole) processAppendEntryEvent(appendTerm int64,
 	// Append entry succeeded and server term did not change
 	if appendTerm == s.currentTerm() && matchIndex != invalidLogID {
 		l.matchIndices[serverID] = matchIndex
-		s.updateCommitIndex(l.matchIndices)
+		s.updateTargetCommitIndex(l.matchIndices)
 		return true
 	}
 
@@ -81,17 +144,18 @@ func (l *leaderRole) requestVote(serverTerm int64, serverID int64,
 // sendEntries notifies the entry replicator about the new log entries to
 // append to the remote server log
 func (l *leaderRole) sendEntries(appendTerm int64, logNextIndex int64,
-	commitIndex int64) {
+	commitIndex int64, s *serverState) {
 	for _, replicator := range l.replicators {
 		replicator.appendEntry(appendTerm, logNextIndex, commitIndex)
 	}
+	s.lastModified = time.Now()
 }
 
-func (l *leaderRole) sendHeartbeat(to time.Duration, s *serverState) {
+func (l *leaderRole) sendHeartbeat(to time.Duration, commitIndex int64,
+	s *serverState) {
 	d := time.Since(s.lastModified)
 	if d >= to {
-		l.sendEntries(s.currentTerm(), s.log.nextIndex(), s.commitIndex)
-		s.lastModified = time.Now()
+		l.sendEntries(s.currentTerm(), s.log.nextIndex(), commitIndex, s)
 	}
 }
 

--- a/src/domain/raft_log.go
+++ b/src/domain/raft_log.go
@@ -1,13 +1,28 @@
 package domain
 
+const (
+	commited = iota
+	appended
+	lost
+	invalid
+)
+
 // logEntry augments a log entry with the term the entry was added to the log
 type logEntry struct {
 	entryTerm int64
 	payload   string
 }
 
+// logEntryStatus represents the status of a log entry. A log entry is
+// committed if has been applied to the replicated state machine; is
+// appended if it has been appended to the log, but has not been applied
+// yet; and is lost if it cannot be found
+type logEntryStatus int64
+
 // abstractRaftLog specifies the interface to be exposed by a log in Raft
 type abstractRaftLog interface {
+	appendEntry(*logEntry) int64
+
 	appendEntries([]*logEntry, int64, int64) bool
 
 	// nextIndex returns the index of the last log entry plus one
@@ -17,6 +32,10 @@ type abstractRaftLog interface {
 // mockRaftLog implements a mock log to be used for unit testing purposes
 type mockRaftLog struct {
 	value bool
+}
+
+func (l *mockRaftLog) appendEntry(_ *logEntry) int64 {
+	return 1
 }
 
 func (l *mockRaftLog) appendEntries(_ []*logEntry, _ int64, _ int64) bool {

--- a/src/domain/raft_log.go
+++ b/src/domain/raft_log.go
@@ -1,7 +1,7 @@
 package domain
 
 const (
-	commited = iota
+	committed = iota
 	appended
 	lost
 	invalid
@@ -25,6 +25,9 @@ type abstractRaftLog interface {
 
 	appendEntries([]*logEntry, int64, int64) bool
 
+	// entryTerm returns the term of the entry with the specified index
+	entryTerm(int64) int64
+
 	// nextIndex returns the index of the last log entry plus one
 	nextIndex() int64
 }
@@ -40,6 +43,10 @@ func (l *mockRaftLog) appendEntry(_ *logEntry) int64 {
 
 func (l *mockRaftLog) appendEntries(_ []*logEntry, _ int64, _ int64) bool {
 	return l.value
+}
+
+func (l *mockRaftLog) entryTerm(idx int64) int64 {
+	return 0
 }
 
 func (l *mockRaftLog) nextIndex() int64 {

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -3,7 +3,8 @@ package domain
 import "time"
 
 const (
-	roleErrCallFmt = "%s should not be called when the server is a %s"
+	roleErrCallFmt  = "%s should not be called when the server is a %s"
+	wrongRoleErrFmt = "server is a %s"
 )
 
 // serverRole defines the interface for a server's role in Raft. There exists
@@ -14,6 +15,12 @@ type serverRole interface {
 	// should append a log entry sent by the current leader to its log
 	appendEntry([]*logEntry, int64, int64, int64, int64, int64,
 		*serverState) (int64, bool)
+
+	// appendNewEntry appends a new log entry sent by a client to the log
+	appendNewEntry(*logEntry, *serverState) (string, int64, error)
+
+	// entryStatus returns the status of a log entry given its key
+	entryStatus(string, *serverState) (logEntryStatus, int64, error)
 
 	// finalizeElection processes the results of an election and handles the
 	// possible transitions from candidate state to either leader or follower

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -17,10 +17,10 @@ type serverRole interface {
 		*serverState) (int64, bool)
 
 	// appendNewEntry appends a new log entry sent by a client to the log
-	appendNewEntry(*logEntry, *serverState) (string, int64, error)
+	appendNewEntry(*logEntry, int64, *serverState) (string, int64, error)
 
 	// entryStatus returns the status of a log entry given its key
-	entryStatus(string, *serverState) (logEntryStatus, int64, error)
+	entryStatus(string, int64, *serverState) (logEntryStatus, int64, error)
 
 	// finalizeElection processes the results of an election and handles the
 	// possible transitions from candidate state to either leader or follower
@@ -46,7 +46,7 @@ type serverRole interface {
 
 	// sendHeartbeat implements the logic to send an heartbeat message to
 	// followers
-	sendHeartbeat(time.Duration, *serverState)
+	sendHeartbeat(time.Duration, int64, *serverState)
 
 	// startElection starts an election. Only candidates can start an election
 	// and be elected: a panic occurs if leaders and followers call this method


### PR DESCRIPTION
This PR implements two endpoints for clients of a Raft service:

* `ApplyCommandAsync` applies a command to the state machine asynchronously;
* `CommandStatus` checks the status of a previously applied command.

An asynchronous implementation is used to simplify the logic behind tracking which requests have succeed and which have not. In addition, this PR introduces a distinction between `commitIndex` and `targetCommitIndex`. `targetCommitIndex` is the commit index that is computed from the remote servers, whereas `commitIndex` is the actual commit index on the local server: the two may differ because log entries are committed asynchronously.