### PR TITLE
Implement Raft log

### DIFF
--- a/src/datasources/log_dao.go
+++ b/src/datasources/log_dao.go
@@ -1,0 +1,84 @@
+package datasources
+
+import (
+	"bufio"
+	"encoding/binary"
+	"math"
+	"os"
+
+	"github.com/giulioborghesi/raft-implementation/src/service"
+)
+
+// AbstractLogDao defines the interface of a log DAO object
+type AbstractLogDao interface {
+	// AppendEntry allows a client to append a log entry to the log and store
+	// it on durable storage
+	AppendEntry(*service.LogEntry) error
+
+	// AppendEntries appends multiple log entries to the log and store them on
+	// durable storage. Entries following the previous log index are dropped
+	AppendEntries([]*service.LogEntry, int64) error
+}
+
+// logDao implements the AbstractLogDao interface using an os file to store log
+// entries on durable storage
+type logDao struct {
+	f       *os.File
+	buffer  []byte
+	offset  int64
+	offsets []int64
+}
+
+func MakeLogFromFile(f *os.File) (AbstractLogDao, []*service.LogEntry, error) {
+	return nil, nil, nil
+}
+
+func (l *logDao) AppendEntry(entry *service.LogEntry) error {
+	return l.AppendEntries([]*service.LogEntry{entry}, math.MaxInt64)
+}
+
+func (l *logDao) AppendEntries(entries []*service.LogEntry,
+	prevEntryIndex int64) error {
+	// Remove old entries if applicable
+	if prevEntryIndex < int64(len(l.offsets)) {
+		bytes := l.offsets[prevEntryIndex]
+		if err := l.f.Truncate(bytes); err != nil {
+			return err
+		}
+		l.offsets = l.offsets[:prevEntryIndex]
+	}
+
+	var bytes int64 = 0
+	offsets := make([]int64, 0)
+
+	w := bufio.NewWriter(l.f)
+	for _, entry := range entries {
+		// Write entry term
+		nv := binary.PutVarint(l.buffer, entry.EntryTerm)
+		l.buffer = l.buffer[:nv]
+		nl, err := w.Write(l.buffer)
+		if err != nil {
+			return err
+		}
+
+		// Write payload
+		np, err := w.WriteString(entry.Payload)
+		if err != nil {
+			return err
+		}
+
+		// Accumulate bytes written and new offsets
+		offsets = append(offsets, l.offset+bytes)
+		bytes += int64(nl + np)
+	}
+
+	// Flush changes to disk
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// Update offsets and return
+	l.offset += bytes
+	l.offsets = append(l.offsets, offsets...)
+	return nil
+}

--- a/src/datasources/mock_server_state_dao.go
+++ b/src/datasources/mock_server_state_dao.go
@@ -1,4 +1,4 @@
-package server_state_dao
+package datasources
 
 // testServerStateDao implements the ServerStateDao interface for use in unit
 // tests

--- a/src/datasources/mysql/mysql_server_state_dao.go
+++ b/src/datasources/mysql/mysql_server_state_dao.go
@@ -1,4 +1,4 @@
-package mysql_server_state_dao
+package mysql_datasources
 
 import (
 	"database/sql"

--- a/src/datasources/mysql/mysql_server_state_dao_test.go
+++ b/src/datasources/mysql/mysql_server_state_dao_test.go
@@ -1,4 +1,4 @@
-package mysql_server_state_dao
+package mysql_datasources
 
 import (
 	"database/sql"

--- a/src/datasources/server_state_dao.go
+++ b/src/datasources/server_state_dao.go
@@ -1,4 +1,4 @@
-package server_state_dao
+package datasources
 
 // ServerStateDao defines the interface of a server state DAO object, which is
 // used to access and persist to disk the term number and the ID of the server

--- a/src/datasources/server_state_dao_with_retry.go
+++ b/src/datasources/server_state_dao_with_retry.go
@@ -1,4 +1,4 @@
-package server_state_dao
+package datasources
 
 import "time"
 

--- a/src/datasources/server_state_dao_with_retry_test.go
+++ b/src/datasources/server_state_dao_with_retry_test.go
@@ -1,4 +1,4 @@
-package server_state_dao
+package datasources
 
 import (
 	"fmt"

--- a/src/domain/candidate_role.go
+++ b/src/domain/candidate_role.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/giulioborghesi/raft-implementation/src/service"
 	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
@@ -12,12 +13,12 @@ type candidateRole struct {
 	voteRequestors []abstractVoteRequestor
 }
 
-func (c *candidateRole) appendEntry(_ []*logEntry, _, _, _, _, _ int64,
+func (c *candidateRole) appendEntry(_ []*service.LogEntry, _, _, _, _, _ int64,
 	s *serverState) (int64, bool) {
 	panic(fmt.Sprintf(roleErrCallFmt, "appendEntry", "candidate"))
 }
 
-func (c *candidateRole) appendNewEntry(_ *logEntry, _ int64,
+func (c *candidateRole) appendNewEntry(_ *service.LogEntry, _ int64,
 	s *serverState) (string, int64, error) {
 	return "", s.leaderID, fmt.Errorf(wrongRoleErrFmt, "candidate")
 }

--- a/src/domain/candidate_role_test.go
+++ b/src/domain/candidate_role_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/datasources"
 	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
@@ -19,7 +19,7 @@ const (
 // MakeCandidateServerState creates and initializes an instance of serverState
 // for a server in candidate mode
 func MakeCandidateServerState() *serverState {
-	dao := server_state_dao.MakeTestServerStateDao()
+	dao := datasources.MakeTestServerStateDao()
 	dao.UpdateTerm(testCandidateStartingTerm)
 	dao.UpdateVotedFor(testCandidateVotedFor)
 

--- a/src/domain/entry_replicator.go
+++ b/src/domain/entry_replicator.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/giulioborghesi/raft-implementation/src/clients"
+	"github.com/giulioborghesi/raft-implementation/src/service"
 )
 
 var (
@@ -140,8 +141,8 @@ func (a *entryReplicator) resetState(appendTerm int64, nextIndex int64) {
 	a.nextIndex = nextIndex
 }
 
-func (a *entryReplicator) sendEntries(entries []*logEntry, prevEntryTerm int64,
-	prevEntryIndex int64) bool {
+func (a *entryReplicator) sendEntries(entries []*service.LogEntry,
+	prevEntryTerm int64, prevEntryIndex int64) bool {
 	// Send entries to remote server
 	remoteTerm, success :=
 		a.client.AppendEntry(a.lastAppendTerm, prevEntryTerm, prevEntryIndex,

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"fmt"
 	"time"
+
+	"github.com/giulioborghesi/raft-implementation/src/service"
 )
 
 const (
@@ -13,8 +15,9 @@ const (
 // followerRole implements the serverRole interface for a follower server
 type followerRole struct{}
 
-func (f *followerRole) appendEntry(entries []*logEntry, serverTerm, serverID,
-	prevLogTerm, prevLogIndex int64, commitIndex int64, s *serverState) (int64, bool) {
+func (f *followerRole) appendEntry(entries []*service.LogEntry, serverTerm,
+	serverID, prevLogTerm, prevLogIndex int64, commitIndex int64,
+	s *serverState) (int64, bool) {
 	// Get current term
 	currentTerm := s.currentTerm()
 	if currentTerm != serverTerm {
@@ -34,7 +37,7 @@ func (f *followerRole) appendEntry(entries []*logEntry, serverTerm, serverID,
 	return currentTerm, success
 }
 
-func (f *followerRole) appendNewEntry(_ *logEntry, _ int64,
+func (f *followerRole) appendNewEntry(_ *service.LogEntry, _ int64,
 	s *serverState) (string, int64, error) {
 	return "", s.leaderID, fmt.Errorf(wrongRoleErrFmt, "follower")
 }

--- a/src/domain/follower_role_test.go
+++ b/src/domain/follower_role_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/datasources"
 	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
@@ -19,7 +19,7 @@ const (
 // MakeFollowerServerState creates and initializes an instance of serverState
 // for a server in follower mode
 func MakeFollowerServerState() *serverState {
-	dao := server_state_dao.MakeTestServerStateDao()
+	dao := datasources.MakeTestServerStateDao()
 	dao.UpdateTerm(testFollowerStartingTerm)
 	dao.UpdateVotedFor(testFollowerVotedFor)
 

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/giulioborghesi/raft-implementation/src/service"
 )
 
 const (
@@ -44,12 +46,12 @@ type leaderRole struct {
 	matchIndices []int64
 }
 
-func (l *leaderRole) appendEntry(_ []*logEntry, _, _, _, _, _ int64,
+func (l *leaderRole) appendEntry(_ []*service.LogEntry, _, _, _, _, _ int64,
 	s *serverState) (int64, bool) {
 	panic(fmt.Sprintf(roleErrCallFmt, "appendEntry", "leader"))
 }
 
-func (l *leaderRole) appendNewEntry(entry *logEntry, commitIndex int64,
+func (l *leaderRole) appendNewEntry(entry *service.LogEntry, commitIndex int64,
 	s *serverState) (string, int64, error) {
 	// Append new entry to log
 	nextLogIndex := s.log.appendEntry(entry)

--- a/src/domain/leader_role_test.go
+++ b/src/domain/leader_role_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/datasources"
 	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
@@ -19,7 +19,7 @@ const (
 // MakeLeaderServerState creates and initializes an instance of serverState
 // for a server in leader mode
 func MakeLeaderServerState() *serverState {
-	dao := server_state_dao.MakeTestServerStateDao()
+	dao := datasources.MakeTestServerStateDao()
 	dao.UpdateTerm(testLeaderStartingTerm)
 	dao.UpdateVotedFor(testLeaderVotedFor)
 

--- a/src/domain/raft_log.go
+++ b/src/domain/raft_log.go
@@ -1,17 +1,13 @@
 package domain
 
+import "github.com/giulioborghesi/raft-implementation/src/service"
+
 const (
 	committed = iota
 	appended
 	lost
 	invalid
 )
-
-// logEntry augments a log entry with the term the entry was added to the log
-type logEntry struct {
-	entryTerm int64
-	payload   string
-}
 
 // logEntryStatus represents the status of a log entry. A log entry is
 // committed if has been applied to the replicated state machine; is
@@ -21,9 +17,9 @@ type logEntryStatus int64
 
 // abstractRaftLog specifies the interface to be exposed by a log in Raft
 type abstractRaftLog interface {
-	appendEntry(*logEntry) int64
+	appendEntry(*service.LogEntry) int64
 
-	appendEntries([]*logEntry, int64, int64) bool
+	appendEntries([]*service.LogEntry, int64, int64) bool
 
 	// entryTerm returns the term of the entry with the specified index
 	entryTerm(int64) int64
@@ -32,16 +28,69 @@ type abstractRaftLog interface {
 	nextIndex() int64
 }
 
+// raftLog implements the abstractRaftLog interface. Log entries are stored
+// in memory for fast access as well as on permanent storage
+type raftLog struct {
+	entries []*service.LogEntry
+}
+
+func (l *raftLog) appendEntry(entry *service.LogEntry) int64 {
+	if entry != nil {
+		l.entries = append(l.entries, entry)
+	}
+	return int64(len(l.entries))
+}
+
+func (l *raftLog) appendEntries(entries []*service.LogEntry,
+	prevEntryTerm int64, prevEntryIndex int64) bool {
+	// Must replace all log entries
+	if prevEntryIndex == 0 {
+		l.entries = entries
+		return true
+	}
+
+	// Previous log entry does not exist
+	if (prevEntryIndex > int64(len(l.entries))) ||
+		(l.entries[prevEntryIndex-1].EntryTerm != prevEntryTerm) {
+		return false
+	}
+
+	// Remove obsolete entries and append new ones
+	l.entries = l.entries[:prevEntryIndex]
+	l.entries = append(l.entries, entries...)
+	return false
+}
+
+func (l *raftLog) entryTerm(idx int64) int64 {
+	// Log entries numbering starts from 1
+	if idx == 0 {
+		return 0
+	}
+
+	// Log entry exists, return its term
+	if idx <= int64(len(l.entries)) {
+		return l.entries[idx-1].EntryTerm
+	}
+
+	// Log entry does not exist, return ID for invalid term
+	return invalidTermID
+}
+
+func (l *raftLog) nextIndex() int64 {
+	return int64(len(l.entries))
+}
+
 // mockRaftLog implements a mock log to be used for unit testing purposes
 type mockRaftLog struct {
 	value bool
 }
 
-func (l *mockRaftLog) appendEntry(_ *logEntry) int64 {
+func (l *mockRaftLog) appendEntry(_ *service.LogEntry) int64 {
 	return 1
 }
 
-func (l *mockRaftLog) appendEntries(_ []*logEntry, _ int64, _ int64) bool {
+func (l *mockRaftLog) appendEntries(_ []*service.LogEntry, _ int64,
+	_ int64) bool {
 	return l.value
 }
 

--- a/src/domain/raft_service_integration_test.go
+++ b/src/domain/raft_service_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/datasources"
 )
 
 const (
@@ -16,7 +16,7 @@ const (
 func createMockRaftService(vr []abstractVoteRequestor,
 	er []abstractEntryReplicator) *raftService {
 	// Create a server state instance
-	dao := server_state_dao.MakeTestServerStateDao()
+	dao := datasources.MakeTestServerStateDao()
 	log := &mockRaftLog{value: true}
 	s := makeServerState(dao, log, testServiceIntegrationLeaderID)
 

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/giulioborghesi/raft-implementation/src/service"
+)
 
 const (
 	roleErrCallFmt  = "%s should not be called when the server is a %s"
@@ -13,11 +17,11 @@ const (
 type serverRole interface {
 	// appendEntry implements the logic used to determine whether a server
 	// should append a log entry sent by the current leader to its log
-	appendEntry([]*logEntry, int64, int64, int64, int64, int64,
+	appendEntry([]*service.LogEntry, int64, int64, int64, int64, int64,
 		*serverState) (int64, bool)
 
 	// appendNewEntry appends a new log entry sent by a client to the log
-	appendNewEntry(*logEntry, int64, *serverState) (string, int64, error)
+	appendNewEntry(*service.LogEntry, int64, *serverState) (string, int64, error)
 
 	// entryStatus returns the status of a log entry given its key
 	entryStatus(string, int64, *serverState) (logEntryStatus, int64, error)

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -3,7 +3,7 @@ package domain
 import (
 	"time"
 
-	server_state_dao "github.com/giulioborghesi/raft-implementation/src/datasources"
+	"github.com/giulioborghesi/raft-implementation/src/datasources"
 	"github.com/giulioborghesi/raft-implementation/src/utils"
 )
 
@@ -18,7 +18,7 @@ const (
 )
 
 // makeServerState creates a serverState instance
-func makeServerState(dao server_state_dao.ServerStateDao,
+func makeServerState(dao datasources.ServerStateDao,
 	log abstractRaftLog, serverID int64) *serverState {
 	s := new(serverState)
 	s.dao = dao
@@ -33,7 +33,7 @@ func makeServerState(dao server_state_dao.ServerStateDao,
 
 // serverState encapsulates the state of a Raft server
 type serverState struct {
-	dao               server_state_dao.ServerStateDao
+	dao               datasources.ServerStateDao
 	log               abstractRaftLog
 	lastModified      time.Time
 	role              int


### PR DESCRIPTION
This PR provides an implement of the log used in Raft. Both an in-memory and a persistent version of the log are provided. In addition, we consolidate the various definitions of `LogEntry` to avoid a circular dependency between the `domain` and the `datasources` packages.