### PR TITLE
Test RequestVote in RaftService integration test

### DIFF
--- a/src/datasources/mock_server_state_dao.go
+++ b/src/datasources/mock_server_state_dao.go
@@ -10,7 +10,7 @@ type testServerStateDao struct {
 // MakeTestServerStateDao creates an instance of testServerStateDao for use
 // outside of this package
 func MakeTestServerStateDao() *testServerStateDao {
-	return &testServerStateDao{}
+	return &testServerStateDao{votedFor: -1}
 }
 
 func (s *testServerStateDao) CurrentTerm() int64 {

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -88,7 +88,6 @@ func (s *raftService) ApplyCommandAsync(entry *service.LogEntry) (string,
 
 func (s *raftService) CommandStatus(key string) (logEntryStatus,
 	int64, error) {
-
 	commitIndex := s.state.targetCommitIndex
 	return s.roles[s.state.role].entryStatus(key, commitIndex, s.state)
 }


### PR DESCRIPTION
This PR adds an integration test for `RaftService` in which the `RequestVote` logic is tested.