### PR TITLE
Fix bugs in log index handling and finalize election logic

### DIFF
--- a/src/clients/raft_client.go
+++ b/src/clients/raft_client.go
@@ -17,7 +17,7 @@ const (
 // provides syntactic sugar to marshall / unmarshall RPC requests / responses
 type AbstractRaftClient interface {
 	// AppendEntry sends an AppendEntry RPC call to a remote server
-	AppendEntry(int64, int64, int64, int64) (int64, bool)
+	AppendEntry([]*service.LogEntry, int64, int64, int64, int64) (int64, bool)
 
 	// RequestVote sends a RequestVote RPC call to a remote server. The request
 	// occurs within a context that must be supplied by the caller
@@ -40,12 +40,14 @@ type raftClient struct {
 	serverID int64
 }
 
-func (c *raftClient) AppendEntry(serverTerm int64, prevEntryTerm int64,
-	prevEntryIndex int64, commitIndex int64) (int64, bool) {
+func (c *raftClient) AppendEntry(entries []*service.LogEntry,
+	serverTerm int64, prevEntryTerm int64, prevEntryIndex int64,
+	commitIndex int64) (int64, bool) {
 	// Create RPC request
-	request := &service.AppendEntryRequest{ServerTerm: serverTerm,
-		ServerID: c.serverID, PrevEntryTerm: prevEntryTerm,
-		PrevEntryIndex: prevEntryIndex, CommitIndex: commitIndex}
+	request := &service.AppendEntryRequest{Entries: entries,
+		ServerTerm: serverTerm, ServerID: c.serverID,
+		PrevEntryTerm: prevEntryTerm, PrevEntryIndex: prevEntryIndex,
+		CommitIndex: commitIndex}
 
 	// On error, request is retried using exponential back-off algorithm
 	count := 0

--- a/src/domain/entry_replicator.go
+++ b/src/domain/entry_replicator.go
@@ -44,6 +44,7 @@ func MakeEntryReplicator(remoteServerID int64, c clients.AbstractRaftClient,
 	a := &entryReplicator{active: false, client: c, service: s,
 		remoteServerID: remoteServerID}
 	a.appendTerm = invalidTermID
+	a.matchIndex = -1
 
 	// Initialize condition variable
 	m := sync.Mutex{}
@@ -104,7 +105,7 @@ func (a *entryReplicator) processEntries() {
 		}
 
 		// Send the log entries to the remote server
-		if ok := a.sendEntries(entries, a.matchIndex, prevEntryTerm); ok {
+		if ok := a.sendEntries(entries, prevEntryTerm, a.matchIndex); ok {
 			a.service.processAppendEntryEvent(appendTerm, a.matchIndex,
 				a.remoteServerID)
 		}
@@ -148,7 +149,7 @@ func (a *entryReplicator) updateMatchIndex(appendTerm int64,
 func (a *entryReplicator) resetState(appendTerm int64, nextIndex int64) {
 	a.lastAppendTerm = appendTerm
 	a.lastLeaderTerm = a.lastAppendTerm
-	a.matchIndex = 0
+	a.matchIndex = -1
 	a.nextIndex = nextIndex
 }
 

--- a/src/domain/entry_replicator.go
+++ b/src/domain/entry_replicator.go
@@ -157,8 +157,8 @@ func (a *entryReplicator) sendEntries(entries []*service.LogEntry,
 	prevEntryTerm int64, prevEntryIndex int64) bool {
 	// Send entries to remote server
 	remoteTerm, success :=
-		a.client.AppendEntry(a.lastAppendTerm, prevEntryTerm, prevEntryIndex,
-			a.commitIndex)
+		a.client.AppendEntry(entries, a.lastAppendTerm, prevEntryTerm,
+			prevEntryIndex, a.commitIndex)
 
 	// Remote server term greater than local term, return
 	if remoteTerm > a.lastAppendTerm {

--- a/src/domain/entry_replicator.go
+++ b/src/domain/entry_replicator.go
@@ -44,7 +44,7 @@ func MakeEntryReplicator(remoteServerID int64, c clients.AbstractRaftClient,
 	a := &entryReplicator{active: false, client: c, service: s,
 		remoteServerID: remoteServerID}
 	a.appendTerm = invalidTermID
-	a.matchIndex = -1
+	a.matchIndex = invalidLogID
 
 	// Initialize condition variable
 	m := sync.Mutex{}
@@ -149,7 +149,7 @@ func (a *entryReplicator) updateMatchIndex(appendTerm int64,
 func (a *entryReplicator) resetState(appendTerm int64, nextIndex int64) {
 	a.lastAppendTerm = appendTerm
 	a.lastLeaderTerm = a.lastAppendTerm
-	a.matchIndex = -1
+	a.matchIndex = invalidLogID
 	a.nextIndex = nextIndex
 }
 

--- a/src/domain/follower_role.go
+++ b/src/domain/follower_role.go
@@ -48,7 +48,7 @@ func (f *followerRole) entryStatus(_ string, _ int64,
 }
 
 func (f *followerRole) finalizeElection(_ int64, _ []requestVoteResult,
-	_ *serverState) {
+	_ *serverState) bool {
 	panic(fmt.Sprintf(roleErrCallFmt, "finalizeElection", "follower"))
 }
 

--- a/src/domain/leader_role.go
+++ b/src/domain/leader_role.go
@@ -86,7 +86,7 @@ func (l *leaderRole) entryStatus(key string, commitIndex int64,
 }
 
 func (l *leaderRole) finalizeElection(_ int64, _ []requestVoteResult,
-	_ *serverState) {
+	_ *serverState) bool {
 	panic(fmt.Sprintf(roleErrCallFmt, "finalizeElection", "leader"))
 }
 

--- a/src/domain/raft_log.go
+++ b/src/domain/raft_log.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"fmt"
+
 	"github.com/giulioborghesi/raft-implementation/src/datasources"
 	"github.com/giulioborghesi/raft-implementation/src/service"
 )
@@ -27,6 +29,10 @@ type abstractRaftLog interface {
 	// entryTerm returns the term of the entry with the specified index
 	entryTerm(int64) int64
 
+	// entries return the log entries at or following the specified index,
+	// together with the term of the log entry at the previous index
+	entries(int64) ([]*service.LogEntry, int64)
+
 	// nextIndex returns the index of the last log entry plus one
 	nextIndex() int64
 }
@@ -34,52 +40,66 @@ type abstractRaftLog interface {
 // raftLog implements the abstractRaftLog interface. Log entries are stored
 // in memory for fast access as well as on permanent storage
 type raftLog struct {
-	entries []*service.LogEntry
+	e []*service.LogEntry
 }
 
 func (l *raftLog) appendEntry(entry *service.LogEntry) int64 {
 	if entry != nil {
-		l.entries = append(l.entries, entry)
+		l.e = append(l.e, entry)
 	}
-	return int64(len(l.entries))
+	return int64(len(l.e))
 }
 
 func (l *raftLog) appendEntries(entries []*service.LogEntry,
 	prevEntryTerm int64, prevEntryIndex int64) bool {
 	// Must replace all log entries
-	if prevEntryIndex == -1 {
-		l.entries = entries
+	if prevEntryIndex == invalidLogID {
+		l.e = entries
 		return true
 	}
 
 	// Previous log entry was removed
-	if (prevEntryIndex >= int64(len(l.entries))) ||
-		(l.entries[prevEntryIndex].EntryTerm != prevEntryTerm) {
+	if (prevEntryIndex >= int64(len(l.e))) ||
+		(l.e[prevEntryIndex].EntryTerm != prevEntryTerm) {
 		return false
 	}
 
 	// Remove obsolete entries and append new ones
-	l.entries = l.entries[:prevEntryIndex+1]
-	l.entries = append(l.entries, entries...)
+	l.e = l.e[:prevEntryIndex+1]
+	l.e = append(l.e, entries...)
 	return false
 }
 
 func (l *raftLog) entryTerm(idx int64) int64 {
-	if idx == -1 {
-		return 0
+	if idx == invalidLogID {
+		return initialTerm
 	}
 
 	// Log entry exists, return its term
-	if idx < int64(len(l.entries)) {
-		return l.entries[idx].EntryTerm
+	if idx < int64(len(l.e)) {
+		return l.e[idx].EntryTerm
 	}
 
 	// Log entry does not exist, return ID for invalid term
 	return invalidTermID
 }
 
+func (l *raftLog) entries(idx int64) ([]*service.LogEntry, int64) {
+	if idx < 0 {
+		panic(fmt.Sprintf("negative log indices not allowed"))
+	}
+
+	var entries []*service.LogEntry = nil
+	if idx < int64(len(l.e)) {
+		entries = l.e[idx:]
+	}
+
+	prevIdx := idx - 1
+	return entries, l.entryTerm(prevIdx)
+}
+
 func (l *raftLog) nextIndex() int64 {
-	return int64(len(l.entries))
+	return int64(len(l.e))
 }
 
 // persistentRaftLog implements a log that stores entries in memory and on
@@ -128,6 +148,10 @@ func (l *mockRaftLog) entryTerm(idx int64) int64 {
 	return 0
 }
 
+func (l *mockRaftLog) entries(idx int64) ([]*service.LogEntry, int64) {
+	return nil, 0
+}
+
 func (l *mockRaftLog) nextIndex() int64 {
-	return 1
+	return 0
 }

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -96,19 +96,16 @@ func (s *raftService) entryInfo(entryIndex int64) (int64, int64) {
 	s.Lock()
 	defer s.Unlock()
 
-	term := s.state.currentTerm()
-	if entryIndex > 0 {
-		return term, invalidTermID
-	}
-	return s.state.currentTerm(), 0
+	return s.state.currentTerm(), s.state.log.entryTerm(entryIndex)
 }
 
-func (s *raftService) entries(int64) ([]*service.LogEntry, int64, int64) {
+func (s *raftService) entries(entryIndex int64) ([]*service.LogEntry, int64,
+	int64) {
 	s.Lock()
 	defer s.Unlock()
 
-	term := s.state.currentTerm()
-	return nil, term, 0
+	entries, prevEntryTerm := s.state.log.entries(entryIndex)
+	return entries, s.state.currentTerm(), prevEntryTerm
 }
 
 func (s *raftService) lastModified() time.Time {

--- a/src/domain/raft_service_integration_test.go
+++ b/src/domain/raft_service_integration_test.go
@@ -25,9 +25,10 @@ type localRaftClient struct {
 	requestVote bool
 }
 
-func (c *localRaftClient) AppendEntry(serverTerm int64, prevEntryTerm int64,
-	prevEntryIndex int64, commitIndex int64) (int64, bool) {
-	return c.s.AppendEntry(nil, serverTerm, c.serverID, prevEntryTerm,
+func (c *localRaftClient) AppendEntry(entries []*service.LogEntry,
+	serverTerm int64, prevEntryTerm int64, prevEntryIndex int64,
+	commitIndex int64) (int64, bool) {
+	return c.s.AppendEntry(entries, serverTerm, c.serverID, prevEntryTerm,
 		prevEntryIndex, commitIndex)
 }
 

--- a/src/domain/raft_service_integration_test.go
+++ b/src/domain/raft_service_integration_test.go
@@ -62,7 +62,7 @@ func createMockRaftCluster() ([]*raftService, [][]*localRaftClient) {
 		// Create a server state instance
 		dao := datasources.MakeTestServerStateDao()
 		log := &raftLog{}
-		log.entries = make([]*service.LogEntry, 0)
+		log.e = make([]*service.LogEntry, 0)
 		s := makeServerState(dao, log, int64(i))
 
 		// Create the raft service

--- a/src/domain/raft_service_integration_test.go
+++ b/src/domain/raft_service_integration_test.go
@@ -20,8 +20,9 @@ const (
 // localRaftClient provides an implementation of RaftClient to be used for
 // unit tests
 type localRaftClient struct {
-	s        *raftService
-	serverID int64
+	s           *raftService
+	serverID    int64
+	requestVote bool
 }
 
 func (c *localRaftClient) AppendEntry(serverTerm int64, prevEntryTerm int64,
@@ -32,6 +33,9 @@ func (c *localRaftClient) AppendEntry(serverTerm int64, prevEntryTerm int64,
 
 func (c *localRaftClient) RequestVote(ctx context.Context,
 	serverTerm int64, serverID int64) (int64, bool, error) {
+	if !c.requestVote {
+		return invalidTermID, false, fmt.Errorf("cannot vote")
+	}
 	currentTerm, success := c.s.RequestVote(serverTerm, serverID)
 	return currentTerm, success, nil
 }
@@ -52,7 +56,7 @@ func createMockRaftService(vr []abstractVoteRequestor,
 	return service
 }
 
-func createMockRaftCluster() []*raftService {
+func createMockRaftCluster() ([]*raftService, [][]*localRaftClient) {
 	services := make([]*raftService, 0, testClusterSize)
 	for i := 0; i < testClusterSize; i++ {
 		// Create a server state instance
@@ -68,13 +72,18 @@ func createMockRaftCluster() []*raftService {
 	}
 
 	// For each service initialize the candidate and leader roles
+	css := make([][]*localRaftClient, 0)
 	for i, service := range services {
 		vr := make([]abstractVoteRequestor, 0, testClusterSize)
 		er := make([]abstractEntryReplicator, 0, testClusterSize)
+
+		cs := make([]*localRaftClient, 0)
 		for j := 0; j < testClusterSize; j++ {
 			if i != j {
 				// Create local client
-				c := &localRaftClient{serverID: int64(i), s: services[j]}
+				c := &localRaftClient{serverID: int64(i), s: services[j],
+					requestVote: true}
+				cs = append(cs, c)
 
 				// Create vote requestor
 				vr = append(vr, makeVoteRequestor(c))
@@ -83,6 +92,7 @@ func createMockRaftCluster() []*raftService {
 				er = append(er, MakeEntryReplicator(int64(j), c, service))
 			}
 		}
+		css = append(css, cs)
 
 		// Initialize match indices
 		matchIndices := make([]int64, testClusterSize)
@@ -91,10 +101,10 @@ func createMockRaftCluster() []*raftService {
 		// Initialize leader and candidate roles
 		service.roles[candidate] = &candidateRole{voteRequestors: vr}
 		service.roles[leader] = &leaderRole{replicators: er,
-			matchIndices: nil}
+			matchIndices: []int64{0, 0, 0}}
 	}
 
-	return services
+	return services, css
 }
 
 func TestLeaderAppendEntry(t *testing.T) {
@@ -182,13 +192,14 @@ func TestLeaderElection(t *testing.T) {
 
 func TestRaftCluster(t *testing.T) {
 	// Create Raft cluster
-	services := createMockRaftCluster()
-	time.Sleep(time.Millisecond * 200)
+	services, clients := createMockRaftCluster()
+	time.Sleep(time.Millisecond)
 
 	// Start a new election
 	leaderID := 0
 	services[leaderID].StartElection(time.Duration(0))
 
+	time.Sleep(time.Millisecond)
 	for serverID := 0; serverID < testClusterSize; serverID++ {
 		// Server with ID equal to leaderID should be the new leader
 		if serverID == leaderID {
@@ -221,6 +232,7 @@ func TestRaftCluster(t *testing.T) {
 	newLeaderID := 1
 	services[newLeaderID].StartElection(time.Minute)
 
+	time.Sleep(time.Millisecond)
 	for serverID := 0; serverID < testClusterSize; serverID++ {
 		// Leader should have not changed
 		if serverID == leaderID {
@@ -245,6 +257,7 @@ func TestRaftCluster(t *testing.T) {
 	// This time, election will succeed
 	services[newLeaderID].StartElection(time.Duration(0))
 
+	time.Sleep(time.Millisecond)
 	for serverID := 0; serverID < testClusterSize; serverID++ {
 		// Leader should have changed to newLeaderID
 		if serverID == newLeaderID {
@@ -268,6 +281,41 @@ func TestRaftCluster(t *testing.T) {
 		currentTerm := services[serverID].state.currentTerm()
 		if currentTerm != 2 {
 			t.Fatalf("invalid term: expected %d, actual %d", 2, currentTerm)
+		}
+	}
+
+	// Consider now a situation where one server does not vote
+	clients[leaderID][1].requestVote = false
+	services[leaderID].StartElection(time.Duration(0))
+
+	time.Sleep(time.Millisecond)
+	for serverID := 0; serverID < testClusterSize; serverID++ {
+		// Leader should have changed to leaderID
+		if serverID == leaderID {
+			if services[serverID].state.role != leader {
+				t.Fatalf("server %d expected to become leader", serverID)
+			}
+		} else {
+			if services[serverID].state.role != follower {
+				t.Fatalf("server %d expected to become follower", serverID)
+			}
+		}
+
+		// All servers but 1 should have voted for new leader
+		_, votedFor := services[serverID].state.votedFor()
+		if serverID == 2 {
+			if votedFor != invalidServerID {
+				t.Fatalf("server %d should have not casted a vote", serverID)
+			}
+		} else if votedFor != int64(leaderID) {
+			t.Fatalf("vote casted for wrong server: "+
+				"expected: %d, actual: %d", leaderID, votedFor)
+		}
+
+		// Current term should now be 3
+		currentTerm := services[serverID].state.currentTerm()
+		if currentTerm != 3 {
+			t.Fatalf("invalid term: expected %d, actual %d", 3, currentTerm)
 		}
 	}
 

--- a/src/domain/server_role.go
+++ b/src/domain/server_role.go
@@ -30,7 +30,7 @@ type serverRole interface {
 	// possible transitions from candidate state to either leader or follower
 	// states. Only candidates can finalize an election: calling this method on
 	// followers and leaders should result in a panic
-	finalizeElection(int64, []requestVoteResult, *serverState)
+	finalizeElection(int64, []requestVoteResult, *serverState) bool
 
 	// makeCandidate implements the role transition logic to candidate
 	makeCandidate(time.Duration, *serverState) bool

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -25,7 +25,7 @@ func makeServerState(dao datasources.ServerStateDao,
 	s.log = log
 	s.lastModified = time.Now()
 	s.role = follower
-	s.targetCommitIndex = 0
+	s.targetCommitIndex = invalidLogID
 	s.leaderID = invalidServerID
 	s.serverID = serverID
 	return s
@@ -60,8 +60,8 @@ func (s *serverState) updateServerState(newRole int, newTerm int64,
 // updateCommitIndex computes the new commit index based on the match indices
 // of the remote servers
 func (s *serverState) updateTargetCommitIndex(matchIndices []int64) {
-	// Make a copy of the match indices
-	indices := []int64{}
+	// Make a deep copy of the match indices slice
+	indices := make([]int64, len(matchIndices))
 	copy(indices, matchIndices)
 
 	// Update match index of local server and sort the resulting slice

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -12,6 +12,7 @@ const (
 	leader
 	candidate
 
+	initialTerm     = 0
 	invalidLogID    = -1
 	invalidServerID = -1
 	invalidTermID   = -1


### PR DESCRIPTION
This PR fixes some bugs in the log indexing that were caused by trying to use 1-offset indexing. This PR also implements the missing bits needed to make the election logic consistent with the one specified by the Raft paper.