### PR TITLE
Add tests for Raft cluster

### DIFF
--- a/src/domain/cluster_simulator.go
+++ b/src/domain/cluster_simulator.go
@@ -107,7 +107,6 @@ func (s *raftClusterSimulator) logs() [][]int64 {
 			log = append(log, entry.EntryTerm)
 		}
 		logs = append(logs, log)
-		fmt.Println(log)
 	}
 	return logs
 }
@@ -129,6 +128,11 @@ func (s *raftClusterSimulator) roles() []int64 {
 	return roles
 }
 
+// sendHeartbeat sends an heartbeat to the followers
+func (s *raftClusterSimulator) sendHearthbeat(serverID int64) {
+	s.services[serverID].sendHeartbeat(0)
+}
+
 // setConnections allows to activate / sever the connections between a server
 // and its peers. Connection states are changed only in one direction
 func (s *raftClusterSimulator) setConnections(serverID int64,
@@ -140,6 +144,10 @@ func (s *raftClusterSimulator) setConnections(serverID int64,
 	for i, status := range clientsStatus {
 		s.clients[serverID][i].(*mockRaftClient).active = status
 	}
+}
+
+func (s *raftClusterSimulator) setServerRole(serverID int64, role int) {
+	s.services[serverID].(*raftService).state.role = role
 }
 
 // startElection starts an election on the specified server

--- a/src/domain/constants.go
+++ b/src/domain/constants.go
@@ -1,5 +1,7 @@
 package domain
 
+import "time"
+
 const (
 	// Empty string
 	emptyString = ""
@@ -17,4 +19,5 @@ const (
 
 	// Unit test constants
 	testStartingTerm = 15
+	testSleepTime    = 10 * time.Millisecond
 )

--- a/src/domain/raft_cluster_test.go
+++ b/src/domain/raft_cluster_test.go
@@ -13,7 +13,7 @@ func TestRaftClusterElection(t *testing.T) {
 	// Server 0 starts an election and gets elected
 	leaderID := int64(0)
 	s.startElection(leaderID, time.Duration(0))
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{0, 0, 0}, s.castedVotes(), t)
 	validateResults([]int64{leader, follower, follower}, s.roles(), t)
@@ -22,7 +22,7 @@ func TestRaftClusterElection(t *testing.T) {
 	// Server 1 starts an election but does not get elected
 	leaderID = int64(1)
 	s.startElection(leaderID, time.Minute)
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{0, 0, 0}, s.castedVotes(), t)
 	validateResults([]int64{leader, follower, follower}, s.roles(), t)
@@ -30,7 +30,7 @@ func TestRaftClusterElection(t *testing.T) {
 
 	// Server 1 starts an election and gets elected
 	s.startElection(leaderID, time.Duration(0))
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{1, 1, 1}, s.castedVotes(), t)
 	validateResults([]int64{follower, leader, follower}, s.roles(), t)
@@ -40,7 +40,7 @@ func TestRaftClusterElection(t *testing.T) {
 	leaderID = int64(2)
 	s.setConnections(leaderID, []bool{true, false})
 	s.startElection(leaderID, time.Duration(0))
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{2, 1, 2}, s.castedVotes(), t)
 	validateResults([]int64{follower, leader, leader}, s.roles(), t)
@@ -48,7 +48,7 @@ func TestRaftClusterElection(t *testing.T) {
 
 	// Restore connections with all servers
 	s.restoreConnections(leaderID)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{2, -1, 2}, s.castedVotes(), t)
 	validateResults([]int64{follower, follower, leader}, s.roles(), t)
@@ -66,7 +66,7 @@ func TestRaftClusterElectionAndAppend(t *testing.T) {
 	// Server 2 starts an election and gets elected
 	leaderID := int64(2)
 	s.startElection(leaderID, time.Duration(0))
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{leaderID, leaderID, leaderID}, s.castedVotes(), t)
 	validateResults([]int64{follower, follower, leader}, s.roles(), t)
@@ -78,7 +78,7 @@ func TestRaftClusterElectionAndAppend(t *testing.T) {
 
 	// A new entry is appended to the leader's log
 	s.applyCommandAsync(leaderID)
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{leaderID, leaderID, leaderID}, s.castedVotes(), t)
 	validateResults([]int64{follower, follower, leader}, s.roles(), t)
@@ -101,13 +101,155 @@ func TestRaftClusterFailedElection(t *testing.T) {
 	// to being a follower
 	leaderID := int64(2)
 	s.startElection(leaderID, time.Duration(0))
-	time.Sleep(time.Millisecond)
+	time.Sleep(testSleepTime)
 
 	validateResults([]int64{-1, leaderID, -1}, s.castedVotes(), t)
 	validateResults([]int64{follower, follower, follower}, s.roles(), t)
 	validateResults([]int64{8, 6, 8}, s.terms(), t)
 
 	expectedLogs := [][]int64{{1, 1, 1}, {1, 4, 4}, {1, 5, 5, 5}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Teardown cluster
+	s.tearDown()
+}
+
+func TestRaftClusterPaperScenario(t *testing.T) {
+	// Create Raft cluster simulator
+	s := makeRaftClusterSimulator([]int64{2, 2, 2, 2, 2},
+		[]int64{0, 0, 0, 0, 0}, [][]int64{{1, 2}, {1, 2}, {1}, {1}, {1}})
+	s.setServerRole(0, leader)
+
+	// Server 4 starts an election. Server 4 can communicate with servers 3 and
+	// 2, but not with servers 0 and 1. Server 0 is death
+	s.setConnections(4, []bool{false, false, true, true})
+	s.startElection(4, time.Duration(0))
+	time.Sleep(testSleepTime)
+
+	roles := []int64{leader, follower, follower, follower, leader}
+	validateResults([]int64{0, 0, 4, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{2, 2, 3, 3, 3}, s.terms(), t)
+
+	expectedLogs := [][]int64{{1, 2}, {1, 2}, {1}, {1}, {1}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Server 4 loses connections with all servers and also receives an apply
+	// command request from a client
+	s.setConnections(4, []bool{false, false, false, false})
+	_, _, _ = s.applyCommandAsync(4)
+	time.Sleep(testSleepTime)
+
+	roles = []int64{leader, follower, follower, follower, leader}
+	validateResults([]int64{0, 0, 4, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{2, 2, 3, 3, 3}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 2}, {1, 2}, {1}, {1}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Server 4 dies and server 0 comes back to life and starts an election
+	s.setConnections(0, []bool{true, true, false, false})
+	s.setServerRole(0, follower)
+	s.startElection(0, time.Duration(0))
+	time.Sleep(testSleepTime)
+
+	roles = []int64{candidate, follower, follower, follower, leader}
+	validateResults([]int64{0, 0, 4, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{3, 3, 3, 3, 3}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 2}, {1, 2}, {1}, {1}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Server 0 was not elected. After timeout, it starts a second election
+	s.startElection(0, time.Duration(0))
+	time.Sleep(testSleepTime)
+
+	roles = []int64{leader, follower, follower, follower, leader}
+	validateResults([]int64{0, 0, 0, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{4, 4, 4, 3, 3}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 2}, {1, 2}, {1, 2}, {1}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Server 0 loses all connections with other servers while receiving an
+	// apply command request from a client
+	s.setConnections(0, []bool{false, false, false, false})
+	_, _, _ = s.applyCommandAsync(0)
+	time.Sleep(testSleepTime)
+
+	roles = []int64{leader, follower, follower, follower, leader}
+	validateResults([]int64{0, 0, 0, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{4, 4, 4, 3, 3}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 2, 4}, {1, 2}, {1, 2}, {1}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Server 4 now comes back to life
+	s.restoreConnections(4)
+	time.Sleep(testSleepTime)
+
+	roles = []int64{leader, follower, follower, follower, follower}
+	validateResults([]int64{0, 0, 0, 4, -1}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{4, 4, 4, 3, 4}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 2, 4}, {1, 2}, {1, 2}, {1, 3}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Server 4 starts an election and gets elected
+	s.startElection(4, time.Duration(0))
+	time.Sleep(testSleepTime)
+
+	roles = []int64{follower, follower, follower, follower, leader}
+	validateResults([]int64{-1, 4, 4, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{5, 5, 5, 5, 5}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 3}, {1, 3}, {1, 3}, {1, 3}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Cluster state doesn't change when connections are re-established
+	s.restoreConnections(0)
+
+	roles = []int64{follower, follower, follower, follower, leader}
+	validateResults([]int64{-1, 4, 4, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{5, 5, 5, 5, 5}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 3}, {1, 3}, {1, 3}, {1, 3}, {1, 3}}
+	for i, log := range s.logs() {
+		validateResults(expectedLogs[i], log, t)
+	}
+
+	// Sending an heartbeat won't change the cluster state
+	s.sendHearthbeat(0)
+
+	roles = []int64{follower, follower, follower, follower, leader}
+	validateResults([]int64{-1, 4, 4, 4, 4}, s.castedVotes(), t)
+	validateResults(roles, s.roles(), t)
+	validateResults([]int64{5, 5, 5, 5, 5}, s.terms(), t)
+
+	expectedLogs = [][]int64{{1, 3}, {1, 3}, {1, 3}, {1, 3}, {1, 3}}
 	for i, log := range s.logs() {
 		validateResults(expectedLogs[i], log, t)
 	}

--- a/src/domain/raft_service.go
+++ b/src/domain/raft_service.go
@@ -119,12 +119,12 @@ func (s *raftService) lastModified() time.Time {
 }
 
 func (s *raftService) processAppendEntryEvent(
-	serverTerm int64, matchIndex int64, serverID int64) {
+	appendTerm int64, matchIndex int64, serverID int64) {
 	// Lock access to server state
 	s.Lock()
 	defer s.Unlock()
 
-	s.roles[s.state.role].processAppendEntryEvent(serverTerm, matchIndex,
+	s.roles[s.state.role].processAppendEntryEvent(appendTerm, matchIndex,
 		serverID, s.state)
 }
 


### PR DESCRIPTION
This PR adds integration tests to verify the correct behavior of a Raft cluster. One of the added test mimics one of the scenarios described in the original Raft paper.