### PR TITLE
Add persistent server state DAO

### DIFF
--- a/src/datasources/errors.go
+++ b/src/datasources/errors.go
@@ -1,0 +1,5 @@
+package datasources
+
+const (
+	corruptedLogFilesErrFmt = "log files corrupted: %s and %s"
+)

--- a/src/datasources/server_state_dao.go
+++ b/src/datasources/server_state_dao.go
@@ -158,7 +158,7 @@ func MakePersistentServerStateDao(pathA string, pathB string) ServerStateDao {
 
 	// At least one file must not be corrupted
 	if errorA != nil && errorB != nil {
-		panic("both log state file are corrupted!")
+		panic(fmt.Sprintf(corruptedLogFilesErrFmt, pathA, pathB))
 	}
 
 	// Ensure most current log state is used

--- a/src/datasources/server_state_dao_test.go
+++ b/src/datasources/server_state_dao_test.go
@@ -1,0 +1,122 @@
+package datasources
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/giulioborghesi/raft-implementation/src/utils"
+)
+
+const (
+	testFileA = "/root/testFileA.bin"
+	testFileB = "/root/testFileB.bin"
+)
+
+func TestInitializeLogStateFromFile(t *testing.T) {
+	// Remove test file A if needed
+	if _, err := os.Stat(testFileA); !os.IsNotExist(err) {
+		os.Remove(testFileA)
+	}
+
+	// Initialize log state file
+	file, currentTerm, votedFor, err :=
+		initializeLogStateFromFile(testFileA)
+
+	utils.ValidateResult(t, utils.InvalidTermErrFmt, 0, currentTerm)
+	utils.ValidateResult(t, utils.InvalidVotedForErrFmt, -1, votedFor)
+
+	if err != nil {
+		t.Fatalf(utils.UnexpectedErrFmt, "none", err)
+	}
+
+	if _, err := os.Stat(testFileA); os.IsNotExist(err) {
+		t.Fatalf(utils.FileNotFoundErrFmt, testFileA)
+	}
+
+	// Close log state file
+	file.Close()
+
+	// Initialize log state file from existing file
+	file, currentTerm, votedFor, err =
+		initializeLogStateFromFile(testFileA)
+
+	utils.ValidateResult(t, utils.InvalidTermErrFmt, 0, currentTerm)
+	utils.ValidateResult(t, utils.InvalidVotedForErrFmt, -1, votedFor)
+
+	if err != io.EOF {
+		t.Fatalf(utils.UnexpectedErrFmt, "EOF", err)
+	}
+
+	// Close and delete log state file
+	file.Close()
+	os.Remove(testFileA)
+}
+
+func TestReadWriteLogState(t *testing.T) {
+	// Remove test file A if needed
+	if _, err := os.Stat(testFileA); !os.IsNotExist(err) {
+		os.Remove(testFileA)
+	}
+
+	// Open log state file
+	file, err := os.OpenFile(testFileA, os.O_RDWR|os.O_CREATE, permissions)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%v", err))
+	}
+
+	// Write log state to file
+	err = writeLogStateToFile(file, 15, 2)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%v", err))
+	}
+
+	// Read log state from file
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%v", err))
+	}
+
+	actualTerm, actualVotedFor, err := readLogStateFromFile(file)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%v", err))
+	}
+
+	utils.ValidateResult(t, utils.InvalidTermErrFmt, 15, actualTerm)
+	utils.ValidateResult(t, utils.InvalidVotedForErrFmt, 2, actualVotedFor)
+
+	// Close and delete log state file
+	file.Close()
+	os.Remove(testFileA)
+}
+
+func TestInMemoryServerStateDao(t *testing.T) {
+	s := &inMemoryServerStateDao{}
+
+	// Fetch current term
+	currentTerm := s.CurrentTerm()
+	utils.ValidateResult(t, utils.InvalidTermErrFmt, 0, currentTerm)
+
+	// Update voted for
+	err := s.UpdateVotedFor(5)
+	if err != nil {
+		t.Fatalf(utils.UnexpectedErrFmt, "none", err)
+	}
+
+	// Check current term and voted for
+	currentTerm, votedFor := s.VotedFor()
+	utils.ValidateResult(t, utils.InvalidTermErrFmt, 0, currentTerm)
+	utils.ValidateResult(t, utils.InvalidVotedForErrFmt, 5, votedFor)
+
+	// Update term
+	err = s.UpdateTerm(8)
+	if err != nil {
+		t.Fatalf(utils.UnexpectedErrFmt, "none", err)
+	}
+
+	// Check current term and voted for
+	currentTerm, votedFor = s.VotedFor()
+	utils.ValidateResult(t, utils.InvalidTermErrFmt, 8, currentTerm)
+	utils.ValidateResult(t, utils.InvalidVotedForErrFmt, -1, votedFor)
+}

--- a/src/domain/server_state.go
+++ b/src/domain/server_state.go
@@ -59,7 +59,9 @@ func (s *serverState) updateTargetCommitIndex(matchIndices []int64) {
 
 	// Return index corresponding to half minus one of the servers
 	k := (len(indices) - 1) / 2
-	s.targetCommitIndex = utils.MaxInt64(s.targetCommitIndex, indices[k])
+	if s.log.entryTerm(indices[k]) == s.currentTerm() {
+		s.targetCommitIndex = utils.MaxInt64(s.targetCommitIndex, indices[k])
+	}
 }
 
 func (s *serverState) updateTerm(serverTerm int64) {

--- a/src/utils/errors.go
+++ b/src/utils/errors.go
@@ -1,0 +1,19 @@
+package utils
+
+import "testing"
+
+const (
+	// Common error messages shared by packages
+	InvalidTermErrFmt     = "invalid term: expected: %d, actual: %d"
+	InvalidVotedForErrFmt = "invalid voted for ID: expected: %d, actual: %d"
+	ChecksumFailedErrFmt  = "invalid checksum: expected: %s, actual: %s"
+
+	FileNotFoundErrFmt = "file %s not found"
+	UnexpectedErrFmt   = "unexpected error: expected: %s, actual: %v"
+)
+
+func ValidateResult(t *testing.T, fmt string, expected int64, actual int64) {
+	if expected != actual {
+		t.Fatalf(fmt, expected, actual)
+	}
+}

--- a/src/utils/math.go
+++ b/src/utils/math.go
@@ -1,5 +1,11 @@
 package utils
 
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+)
+
 // Max returns the maximum of two int64 values
 func MaxInt64(x, y int64) int64 {
 	if x < y {
@@ -14,4 +20,13 @@ func MaxInt(x, y int) int {
 		return y
 	}
 	return x
+}
+
+// Int64PairCheckSum computes the checksum of a pair of int64 values
+func Int64PairCheckSum(lhs int64, rhs int64) [28]byte {
+	w := &bytes.Buffer{}
+	binary.Write(w, binary.LittleEndian, lhs)
+	binary.Write(w, binary.LittleEndian, rhs)
+	checkSum := sha256.Sum224(w.Bytes())
+	return checkSum
 }

--- a/src/utils/math_test.go
+++ b/src/utils/math_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+const (
+	testEncodedChecksumA = "351d38fe"
+	testEncodedChecksumB = "453c31e5"
+)
+
+func TestInt64PairCheckSum(t *testing.T) {
+	// Compute checksum for two numbers
+	checksumA := Int64PairCheckSum(1565, 21)
+	encodedA := hex.EncodeToString(checksumA[:])
+
+	if encodedA[:8] != testEncodedChecksumA {
+		t.Fatalf(ChecksumFailedErrFmt, testEncodedChecksumA, encodedA[:8])
+	}
+
+	// Compute checksum for inverse pair
+	checksumB := Int64PairCheckSum(21, 1565)
+	encodedB := hex.EncodeToString(checksumB[:])
+
+	if encodedB[:8] != testEncodedChecksumB {
+		t.Fatalf(ChecksumFailedErrFmt, testEncodedChecksumB, encodedB[:8])
+	}
+}


### PR DESCRIPTION
This PR adds an implementation of a server state DAO that persists data to a disk file. The implementation uses two files to ensure that, in the event of a catastrophic error, a backup copy is available. 